### PR TITLE
Add gem dependency on psych >= 3.3.0 for Psych.safe_load_file

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     reviewer (0.1.4)
       colorize
+      psych (>= 3.3.0)
       slop
 
 GEM

--- a/reviewer.gemspec
+++ b/reviewer.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'colorize'
   spec.add_dependency 'slop'
+  spec.add_dependency 'psych', '>= 3.3.0'
 
   spec.add_development_dependency 'bundler-audit'
   spec.add_development_dependency 'codecov'


### PR DESCRIPTION
`reviewer` uses `Psych.safe_load_file` to load its configuration. However, this method was first added in Psych 3.3.0 ([as far as I can tell](https://github.com/ruby/psych/commit/0210e310d04cbc9b236ccdde6caaf79aab4eb794)), and is not present in the bundled `psych` gem in Ruby 2.5.9 (ships with psych 3.0.2), Ruby 2.6.9 or 2.7.5 (both ship with psych 3.1.0). Ruby 3 and greater are fine (3.0.3 ships with 3.3.2).

This leads to an exception when running `rvw`:

```
Traceback (most recent call last):
	15: from /Users/cypher/.rbenv/versions/2.7.5/bin/rvw:25:in `<main>'
	14: from /Users/cypher/.rbenv/versions/2.7.5/bin/rvw:25:in `load'
	13: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/exe/rvw:7:in `<top (required)>'
	12: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer.rb:41:in `review'
	11: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer.rb:114:in `perform'
	10: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/tools.rb:63:in `current'
	 9: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/tools.rb:74:in `subset?'
	 8: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/tools.rb:86:in `tool_names'
	 7: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/arguments/keywords.rb:71:in `for_tool_names'
	 6: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/arguments/keywords.rb:109:in `configured_tool_names'
	 5: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/tools.rb:31:in `all'
	 4: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/tools.rb:78:in `configured'
	 3: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/loader.rb:28:in `configuration'
	 2: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/loader.rb:28:in `new'
	 1: from /Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/loader.rb:18:in `initialize'
/Users/cypher/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/reviewer-0.1.4/lib/reviewer/loader.rb:52:in `configuration_hash': undefined method `safe_load_file' for Psych:Module (NoMethodError)
Did you mean?  safe_load
```

As a workaround, installing psych 3.3.2 or greater makes `rvw` work: `gem install psych -v 3.3.2`

Note: This issue doesn't make reviewer's tests fail, because it has a development dependency on `reek`, which currently installs psych 3.3.2 when running `bundle install`, so `bundle exec rake test` works.

This PR solves this by making `psych >= 3.3.0` an explicit gem dependency.