### PR TITLE
feat: expand code review tools and add raw output mode

### DIFF
--- a/.reviewer.yml
+++ b/.reviewer.yml
@@ -128,13 +128,130 @@ yard:
 alex:
   disabled: true
   tags: [language, docs]
-  name: Yard
-  description: Generates Documentation
+  name: Alex
+  description: Catch insensitive, inconsiderate writing
   links:
-    home:
-    usage:
-    install:
+    home: https://alexjs.com
   commands:
     install: 'yarn global add alex'
     review: 'alex .'
-    quiet_flag: '--quiet'
+
+
+# New tools for expanded testing coverage
+
+brakeman:
+  disabled: true  # Requires Rails application, not applicable to gems
+  name: Brakeman
+  description: Static analysis security scanner for Ruby
+  tags: [security, ruby, dev]
+  links:
+    home: https://brakemanscanner.org
+    install: https://brakemanscanner.org/docs/install/
+  commands:
+    install: 'bundle exec gem install brakeman'
+    review: 'bundle exec brakeman --no-pager -q'
+
+
+fasterer:
+  name: Fasterer
+  description: Suggest performance improvements for Ruby code
+  tags: [ruby, quality, performance, dev]
+  links:
+    home: https://github.com/DamirSvrtan/fasterer
+  commands:
+    install: 'bundle exec gem install fasterer'
+    review: 'bundle exec fasterer'
+
+
+debride:
+  disabled: true  # Broken on Ruby 3.4 (missing require for Racc, Timeout)
+  name: Debride
+  description: Find potentially unused methods and classes
+  tags: [ruby, quality, dev]
+  links:
+    home: https://github.com/seattlerb/debride
+  commands:
+    install: 'bundle exec gem install debride'
+    review: 'bundle exec debride lib/'
+
+
+rubycritic:
+  disabled: true  # Generates HTML reports, best run manually
+  name: RubyCritic
+  description: Code quality analysis with HTML reports
+  tags: [ruby, quality, dev]
+  links:
+    home: https://github.com/whitesmith/rubycritic
+  commands:
+    install: 'bundle exec gem install rubycritic'
+    review: 'bundle exec rubycritic lib/ --no-browser -f console'
+
+
+metric_fu:
+  disabled: true  # Meta-tool that runs many others, slow
+  name: MetricFu
+  description: Aggregate code metrics from multiple tools
+  tags: [ruby, quality, dev]
+  links:
+    home: https://github.com/metricfu/metric_fu
+  commands:
+    install: 'bundle exec gem install metric_fu'
+    review: 'bundle exec metric_fu'
+
+
+yardstick:
+  disabled: true  # Documentation coverage measurement
+  name: Yardstick
+  description: Measure YARD documentation coverage
+  tags: [docs, ruby, dev]
+  links:
+    home: https://github.com/dkubb/yardstick
+  commands:
+    install: 'bundle exec gem install yardstick'
+    review: 'bundle exec yardstick lib/'
+
+
+standard:
+  disabled: true  # Conflicts with existing RuboCop configuration
+  name: Standard
+  description: Zero-configuration Ruby linter
+  tags: [ruby, syntax, dev]
+  links:
+    home: https://github.com/standardrb/standard
+  commands:
+    install: 'bundle exec gem install standard'
+    review: 'bundle exec standardrb'
+    format: 'bundle exec standardrb --fix'
+
+
+rufo:
+  disabled: true  # Alternative formatter to RuboCop
+  name: Rufo
+  description: Ruby code formatter
+  tags: [ruby, syntax, dev]
+  links:
+    home: https://github.com/ruby-formatter/rufo
+  commands:
+    install: 'bundle exec gem install rufo'
+    review: 'bundle exec rufo --check lib/'
+    format: 'bundle exec rufo lib/'
+
+
+license_finder:
+  name: License Finder
+  description: Check dependency licenses for compliance
+  tags: [dependencies, compliance, dev]
+  links:
+    home: https://github.com/pivotal/LicenseFinder
+  commands:
+    install: 'bundle exec gem install license_finder'
+    review: 'bundle exec license_finder --decisions-file=./dependency_decisions.yml'
+
+
+notes:
+  name: Notes
+  description: Find TODO, FIXME, HACK, and OPTIMIZE comments
+  tags: [quality, dev]
+  commands:
+    review: "grep -rn --include='*.rb' -E '(TODO|FIXME|HACK|OPTIMIZE|XXX):?' lib/ test/ || true"
+  max_exit_status: 1

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
   UseCache: true
@@ -23,3 +23,11 @@ Gemspec/DevelopmentDependencies:
 Metrics/MethodLength:
   CountAsOne: ['array', 'hash', 'heredoc']
   Max: 15
+
+# Fasterer prefers yield over block.call for performance
+Style/ExplicitBlockArgument:
+  Enabled: false
+
+# Fasterer prefers fetch with block over second argument for performance
+Style/RedundantFetchBlock:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## [Unreleased]
 
+### Added
+- Add `--raw` / `-r` flag to force passthrough output (useful for CI/agent contexts)
+- Add expanded code review tools: fasterer, license_finder, notes (enabled); debride, brakeman, rubycritic, metric_fu, yardstick, standard, rufo (disabled)
+- Add license_finder configuration with approved open source licenses
+
+### Fixed
+- Restore MIT license in LICENSE.txt to match gemspec declaration
+
+### Changed
+- Update RuboCop target to Ruby 3.2
+- Apply fasterer performance suggestions (yield over block.call, fetch with block)
+
+---
+
 - TODO: Improve and streamline installation
 - TODO: Add support for targeting specific files
 

--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,36 @@ gem 'zeitwerk', '>= 2.6', '< 2.7'
 gem 'bundler-audit'
 
 # Self-review tools - not required for running tests
-# Install with: bundle install --with lint
+# Install with: bundle config set --local with lint && bundle install
 group :lint, optional: true do
-  gem 'flay'
-  gem 'flog'
-  gem 'reek'
+  # Ruby 3.4+ requires explicit racc (no longer a default gem)
+  gem 'racc'
+
+  # Style & Linting
   gem 'rubocop'
   gem 'rubocop-minitest'
   gem 'rubocop-rake'
+  gem 'standard', '>= 1.35.1'
+
+  # Code Quality & Complexity
+  gem 'debride'
+  gem 'fasterer'
+  gem 'flay'
+  gem 'flog'
+  gem 'metric_fu'
+  gem 'reek'
+  gem 'rubycritic'
+
+  # Security
+  gem 'brakeman'
+
+  # Documentation
+  gem 'inch'
+  gem 'yardstick'
+
+  # Formatting
+  gem 'rufo'
+
+  # Compliance
+  gem 'license_finder'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,14 +10,61 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (8.1.1)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.3.1)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      json
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0, >= 2.0.5)
+      uri (>= 0.13.1)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    arrayfields (4.9.2)
     ast (2.4.3)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
+    base64 (0.3.0)
     benchmark (0.5.0)
     bigdecimal (3.3.1)
+    brakeman (7.1.1)
+      racc
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    cane (2.6.2)
+      parallel
+    chronic (0.10.2)
+    churn (1.0.8)
+      chronic (>= 0.2.3)
+      hirb
+      main
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.1)
+    code_analyzer (0.5.5)
+      sexp_processor
+    code_metrics (0.1.3)
+    coderay (1.1.3)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     concurrent-ruby (1.3.6)
+    connection_pool (3.0.2)
+    csv (3.3.5)
+    debride (1.14.0)
+      path_expander (~> 2.0)
+      prism (~> 1.5)
+      sexp_processor (~> 4.17)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     docile (1.4.1)
+    drb (2.2.3)
     dry-configurable (1.3.0)
       dry-core (~> 1.1)
       zeitwerk (~> 2.6)
@@ -48,6 +95,10 @@ GEM
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
     erubi (1.13.1)
+    erubis (2.7.0)
+    fasterer (0.11.0)
+      ruby_parser (>= 3.19.1)
+    fattr (2.4.0)
     flay (2.14.0)
       erubi (~> 1.10)
       path_expander (~> 2.0)
@@ -57,23 +108,82 @@ GEM
       path_expander (~> 2.0)
       prism (~> 1.5)
       sexp_processor (~> 4.8)
+    hirb (0.7.3)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
+    inch (0.8.0)
+      pry
+      sparkr (>= 0.2.0)
+      term-ansicolor
+      yard (~> 0.9.12)
+    io-console (0.8.2)
     json (2.18.0)
     language_server-protocol (3.17.0.5)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    license_finder (7.2.1)
+      bundler
+      csv (~> 3.2)
+      rubyzip (>= 1, < 3)
+      thor (~> 1.2)
+      tomlrb (>= 1.3, < 2.1)
+      with_env (= 1.1.0)
+      xml-simple (~> 1.1.9)
     lint_roller (1.1.0)
     logger (1.7.0)
+    main (6.4.0)
+      arrayfields (~> 4.9, >= 4.9.2)
+      chronic (~> 0.10, >= 0.10.2)
+      fattr (~> 2.4, >= 2.4.0)
+      map (~> 6.6, >= 6.6.0)
+    map (6.6.0)
+    method_source (1.1.0)
+    metric_fu (4.13.0)
+      cane (~> 2.5, >= 2.5.2)
+      churn (~> 1.0, >= 1.0.2)
+      code_metrics (~> 0.1)
+      coderay
+      flay (~> 2.1, >= 2.0.1)
+      flog (~> 4.1, >= 4.1.1)
+      launchy (~> 2.0)
+      metric_fu-Saikuro (~> 1.1, >= 1.1.3)
+      multi_json
+      rails_best_practices (~> 1.14, >= 1.14.3)
+      redcard
+      reek (>= 5.4.0)
+      roodi (~> 5.0.0)
+    metric_fu-Saikuro (1.1.3)
     minitest (5.27.0)
     minitest-heat (1.2.0)
       minitest
+    mize (0.6.1)
+    multi_json (1.18.0)
     parallel (1.27.0)
     parser (3.3.10.0)
       ast (~> 2.4.1)
       racc
     path_expander (2.0.0)
     prism (1.7.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     pstore (0.2.0)
+    public_suffix (7.0.0)
     racc (1.8.1)
+    rails_best_practices (1.23.3)
+      activesupport
+      code_analyzer (~> 0.5.5)
+      erubis
+      i18n
+      json
+      require_all (~> 3.0)
+      ruby-progressbar
     rainbow (3.1.1)
     rake (13.3.1)
+    readline (0.0.4)
+      reline
+    redcard (1.1.0)
     reek (6.5.0)
       dry-schema (~> 1.13)
       logger (~> 1.6)
@@ -81,8 +191,13 @@ GEM
       rainbow (>= 2.0, < 4.0)
       rexml (~> 3.1)
     regexp_parser (2.11.3)
+    reline (0.6.3)
+      io-console (~> 0.5)
+    require_all (3.0.0)
     rexml (3.4.4)
-    rubocop (1.82.0)
+    roodi (5.0.0)
+      ruby_parser (~> 3.2, >= 3.2.2)
+    rubocop (1.81.7)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -90,7 +205,7 @@ GEM
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 2.9.3, < 3.0)
-      rubocop-ast (>= 1.48.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
     rubocop-ast (1.48.0)
@@ -100,10 +215,32 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
+    rubocop-performance (1.26.1)
+      lint_roller (~> 1.1)
+      rubocop (>= 1.75.0, < 2.0)
+      rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)
       rubocop (>= 1.72.1)
     ruby-progressbar (1.13.0)
+    ruby_parser (3.22.0)
+      racc (~> 1.5)
+      sexp_processor (~> 4.16)
+    rubycritic (4.11.0)
+      flay (~> 2.13)
+      flog (~> 4.7)
+      launchy (>= 2.5.2)
+      parser (>= 3.3.0.5)
+      rainbow (~> 3.1.1)
+      reek (~> 6.5.0, < 7.0)
+      rexml
+      ruby_parser (~> 3.21)
+      simplecov (>= 0.22.0)
+      tty-which (~> 0.5.0)
+      virtus (~> 2.0)
+    rubyzip (2.4.1)
+    rufo (0.18.1)
+    securerandom (0.4.1)
     sexp_processor (4.17.4)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -112,11 +249,47 @@ GEM
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
+    sparkr (0.4.1)
+    standard (1.52.0)
+      language_server-protocol (~> 3.17.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.81.7)
+      standard-custom (~> 1.0.0)
+      standard-performance (~> 1.8)
+    standard-custom (1.0.2)
+      lint_roller (~> 1.0)
+      rubocop (~> 1.50)
+    standard-performance (1.9.0)
+      lint_roller (~> 1.1)
+      rubocop-performance (~> 1.26.0)
+    sync (0.5.0)
+    term-ansicolor (1.11.3)
+      tins (~> 1)
     thor (1.4.0)
+    thread_safe (0.3.6)
+    tins (1.51.0)
+      bigdecimal
+      mize (~> 0.6)
+      readline
+      sync
+    tomlrb (2.0.4)
+    tty-which (0.5.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.2.0)
+    uri (1.1.1)
+    virtus (2.0.0)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+    with_env (1.1.0)
+    xml-simple (1.1.9)
+      rexml
     yard (0.9.38)
+    yardstick (0.9.9)
+      yard (~> 0.8, >= 0.8.7.2)
     zeitwerk (2.6.18)
 
 PLATFORMS
@@ -124,20 +297,31 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  brakeman
   bundler-audit
+  debride
+  fasterer
   flay
   flog
+  inch
+  license_finder
+  metric_fu
   minitest (~> 5.0)
   minitest-heat
+  racc
   rake (~> 13.2)
   reek
   reviewer!
   rubocop
   rubocop-minitest
   rubocop-rake
+  rubycritic
+  rufo
   simplecov
   simplecov_json_formatter
+  standard (>= 1.35.1)
   yard
+  yardstick
   zeitwerk (>= 2.6, < 2.7)
 
 BUNDLED WITH

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,21 @@
-Copyright (c) Garrett Dimon
+The MIT License (MIT)
 
-Reviewer is an Open Source project licensed under the terms of
-the LGPLv3 license. Please see <http://www.gnu.org/licenses/lgpl-3.0.html>
-for license text.
+Copyright (c) 2021 Garrett Dimon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/dependency_decisions.yml
+++ b/dependency_decisions.yml
@@ -1,0 +1,61 @@
+---
+- - :permit
+  - MIT
+  - :who:
+    :why: Standard permissive license
+    :versions: []
+    :when: 2025-12-22 19:15:00.637887000 Z
+- - :permit
+  - Apache 2.0
+  - :who:
+    :why: Standard permissive license
+    :versions: []
+    :when: 2025-12-22 19:15:01.182813000 Z
+- - :permit
+  - Simplified BSD
+  - :who:
+    :why: Standard permissive license
+    :versions: []
+    :when: 2025-12-22 19:15:01.670547000 Z
+- - :permit
+  - Simplified BSD, ruby
+  - :who:
+    :why: Ruby standard library license
+    :versions: []
+    :when: 2025-12-22 19:15:02.138662000 Z
+- - :permit
+  - ruby
+  - :who:
+    :why: Ruby license
+    :versions: []
+    :when: 2025-12-22 19:15:02.611904000 Z
+- - :permit
+  - same as ruby's
+  - :who:
+    :why: Ruby license variant
+    :versions: []
+    :when: 2025-12-22 19:15:03.091953000 Z
+- - :permit
+  - ISC
+  - :who:
+    :why: Standard permissive license
+    :versions: []
+    :when: 2025-12-22 19:15:03.570618000 Z
+- - :permit
+  - BSD
+  - :who:
+    :why: Standard permissive license
+    :versions: []
+    :when: 2025-12-22 19:15:04.055284000 Z
+- - :permit
+  - GPL-3.0-or-later
+  - :who:
+    :why: Acceptable for development tools
+    :versions: []
+    :when: 2025-12-22 19:15:12.998894000 Z
+- - :approve
+  - brakeman
+  - :who:
+    :why: Development-only security scanner with custom license
+    :versions: []
+    :when: 2025-12-22 19:15:13.454537000 Z

--- a/lib/reviewer.rb
+++ b/lib/reviewer.rb
@@ -27,8 +27,8 @@ module Reviewer
   class Error < StandardError; end
 
   class << self
-    # Resets the loaded tools
-    def reset! = @tools = nil
+    # Resets the loaded tools and arguments
+    def reset! = @tools = @arguments = nil
 
     # Runs the `review` command for the specified tools/files. Reviewer expects all configured
     #   commands that are not disabled to have an entry for the `review` command.

--- a/lib/reviewer/arguments.rb
+++ b/lib/reviewer/arguments.rb
@@ -39,6 +39,7 @@ module Reviewer
       @options = Slop.parse options do |opts|
         opts.array '-f', '--files', 'a list of comma-separated files or paths', delimiter: ',', default: []
         opts.array '-t', '--tags', 'a list of comma-separated tags', delimiter: ',', default: []
+        opts.on '-r', '--raw', 'force raw output (no capturing)'
 
         opts.on '-v', '--version', 'print the version' do
           @output.help VERSION
@@ -78,5 +79,10 @@ module Reviewer
     #
     # @return [Arguments::Keywords] an collection of the leftover arguments as keywords
     def keywords = @keywords ||= Arguments::Keywords.new(options.arguments)
+
+    # Whether to force raw/passthrough output regardless of tool count
+    #
+    # @return [Boolean] true if raw output mode is requested
+    def raw? = options[:raw]
   end
 end

--- a/lib/reviewer/batch.rb
+++ b/lib/reviewer/batch.rb
@@ -45,7 +45,12 @@ module Reviewer
     private
 
     def multiple_tools? = tools.size > 1
-    def strategy = multiple_tools? ? Runner::Strategies::Captured : Runner::Strategies::Passthrough
+
+    def strategy
+      return Runner::Strategies::Passthrough if Reviewer.arguments.raw?
+
+      multiple_tools? ? Runner::Strategies::Captured : Runner::Strategies::Passthrough
+    end
 
     # Notes the exit status for the runner based on whether the runner was considered successful or
     #   not based on the configured `max_exit_status` for the tool. For example, some tools use exit

--- a/lib/reviewer/runner/strategies/captured.rb
+++ b/lib/reviewer/runner/strategies/captured.rb
@@ -55,11 +55,11 @@ module Reviewer
         #   progress updated and printed
         #
         # @return [void]
-        def display_progress(command, &block) # rubocop:disable Metrics/AbcSize
+        def display_progress(command) # rubocop:disable Metrics/AbcSize
           start_time = Time.now
           average_time = runner.tool.average_time(command)
 
-          thread = Thread.new { block.call }
+          thread = Thread.new { yield }
 
           while thread.alive?
             elapsed = (Time.now - start_time).to_f.round(1)

--- a/lib/reviewer/tool/settings.rb
+++ b/lib/reviewer/tool/settings.rb
@@ -26,7 +26,7 @@ module Reviewer
       end
       alias :== eql?
 
-      def disabled? = config.fetch(:disabled, false)
+      def disabled? = config.fetch(:disabled) { false }
       def enabled? = !disabled?
 
       def name = config.fetch(:name) { tool_key.to_s.capitalize }
@@ -44,7 +44,7 @@ module Reviewer
       # The largest exit status that can still be considered a success for the command
       #
       # @return [Integer] the configured `max_exit_status` for the tool or 0 if one isn't configured
-      def max_exit_status = commands.fetch(:max_exit_status, 0)
+      def max_exit_status = commands.fetch(:max_exit_status) { 0 }
 
       protected
 

--- a/test/reviewer/arguments_test.rb
+++ b/test/reviewer/arguments_test.rb
@@ -90,5 +90,26 @@ module Reviewer
       assert hash.key?(:tags)
       assert hash.key?(:keywords)
     end
+
+    def test_raw_is_false_by_default
+      arguments = Arguments.new([])
+      refute arguments.raw?
+    end
+
+    def test_parses_short_raw_flag
+      arguments = Arguments.new(%w[-r])
+      assert arguments.raw?
+    end
+
+    def test_parses_long_raw_flag
+      arguments = Arguments.new(%w[--raw])
+      assert arguments.raw?
+    end
+
+    def test_raw_flag_works_with_other_options
+      arguments = Arguments.new(%w[-r -t ruby staged])
+      assert arguments.raw?
+      assert_equal %w[ruby], arguments.tags.raw
+    end
   end
 end

--- a/test/reviewer/batch_test.rb
+++ b/test/reviewer/batch_test.rb
@@ -29,5 +29,17 @@ module Reviewer
       expected_result = { list: 0, minimum_viable_tool: 0 }
       assert_equal expected_result, @result
     end
+
+    def test_uses_passthrough_strategy_when_raw_flag_set
+      Reviewer.instance_variable_set(:@arguments, Arguments.new(%w[-r]))
+
+      tools = [Tool.new(:list), Tool.new(:minimum_viable_tool)]
+      batch = Batch.new(:review, tools)
+
+      assert_equal Runner::Strategies::Passthrough, batch.send(:strategy)
+    ensure
+      Reviewer.reset!
+      ensure_test_configuration!
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Restore MIT license to match gemspec (was inconsistent since Dec 2021)
- Add expanded code review tools with license_finder compliance config
- Add `--raw` / `-r` flag for passthrough output (useful for CI/agents)
- Apply fasterer performance suggestions and update RuboCop config

## New Tools

**Enabled:**
- `fasterer` - Ruby performance suggestions
- `license_finder` - Dependency license compliance
- `notes` - Find TODO/FIXME/HACK comments

**Disabled (available for opt-in):**
- `debride` - Unused method detection (broken on Ruby 3.4)
- `brakeman`, `rubycritic`, `metric_fu`, `yardstick`, `standard`, `rufo`

## Raw Output Mode

The new `--raw` flag forces passthrough output even with multiple tools:

```bash
# Captured output (default) - progress spinners, buffered
bundle exec rvw

# Raw output - streams each tool's output directly
bundle exec rvw --raw
bundle exec rvw -r
```

This makes output parseable for agents and CI systems.

## Test plan

- [x] All 176 tests pass
- [x] `bundle exec rvw --raw` streams output correctly
- [x] `bundle exec rvw -h` shows new flag
- [x] `bundle exec license_finder` passes with config