### PR TITLE
Improve release process with automation and documentation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,13 +3,16 @@ name: CI
 on:
   push:
     branches: [main]
+    tags-ignore:
+      - 'v*'
   pull_request:
 
 env:
   CI: true
 
 jobs:
-  audit:
+  security:
+    name: Security
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -24,12 +27,12 @@ jobs:
       run: bundle exec bundle-audit check
 
   test:
+    name: Test (Ruby ${{ matrix.ruby }})
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0.0-preview3']
+        ruby: ['3.2', '3.3', '3.4', '4.0']
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.ruby == '4.0.0-preview3' }}
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby
@@ -37,5 +40,54 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-    - name: Run Tests
-      run: bundle exec rake
+    - name: Run tests
+      run: bundle exec rake test
+
+  changelog:
+    name: Changelog
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Validate changelog format
+      run: |
+        # Check [Unreleased] section exists
+        if ! grep -q '## \[Unreleased\]' CHANGELOG.md; then
+          echo "::error::CHANGELOG.md missing [Unreleased] section"
+          exit 1
+        fi
+
+        # Check version entries have dates (## [X.Y.Z] - YYYY-MM-DD)
+        bad_entries=$(grep -E '## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md | grep -v ' - [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' || true)
+        if [ -n "$bad_entries" ]; then
+          echo "::error::Version entries must have dates (## [X.Y.Z] - YYYY-MM-DD)"
+          echo "$bad_entries"
+          exit 1
+        fi
+
+        echo "Changelog format valid"
+
+  version:
+    name: Version
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+    - name: Check version consistency
+      run: |
+        VERSION=$(ruby -r./lib/reviewer/version -e "puts Reviewer::VERSION")
+
+        # If version has a CHANGELOG entry, it should have a date
+        if grep -q "\[${VERSION}\]" CHANGELOG.md; then
+          # Verify the version entry includes a date (YYYY-MM-DD)
+          if ! grep "\[${VERSION}\]" CHANGELOG.md | grep -q ' - [0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}'; then
+            echo "::error::Version ${VERSION} in CHANGELOG is missing release date"
+            exit 1
+          fi
+          echo "Version ${VERSION} has dated changelog entry"
+        else
+          echo "Version ${VERSION} not yet released (under Unreleased section)"
+        fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: Verify tag is on main branch
+      run: |
+        TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref }})
+        if ! git merge-base --is-ancestor $TAG_COMMIT origin/main; then
+          echo "::error::Release tags must point to a commit on the main branch."
+          echo "::error::This ensures the code has passed CI before release."
+          exit 1
+        fi
+        echo "Tag points to commit on main branch"
+
+  publish:
+    name: Publish
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: rubygems
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.4'
+        bundler-cache: true
+    - name: Build gem
+      run: gem build reviewer.gemspec
+    - name: Push to RubyGems
+      uses: rubygems/release-gem@v1
+
+  github-release:
+    name: GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Extract version from tag
+      id: version
+      run: echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+    - name: Extract changelog for version
+      id: changelog
+      run: |
+        # Extract the section for this version from CHANGELOG.md
+        version="${{ steps.version.outputs.version }}"
+        changelog=$(awk -v ver="$version" '
+          /^## \[/ {
+            if (found) exit
+            if ($0 ~ "\\[" ver "\\]") found=1
+            next
+          }
+          found { print }
+        ' CHANGELOG.md)
+
+        # Handle multi-line output
+        {
+          echo "content<<EOF"
+          echo "$changelog"
+          echo "EOF"
+        } >> $GITHUB_OUTPUT
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: v${{ steps.version.outputs.version }}
+        body: |
+          ## Changes
+
+          ${{ steps.changelog.outputs.content }}
+
+          ## Installation
+
+          ```bash
+          gem install reviewer -v ${{ steps.version.outputs.version }}
+          ```
+
+          Or add to your Gemfile:
+
+          ```ruby
+          gem 'reviewer', '~> ${{ steps.version.outputs.version }}'
+          ```
+        draft: false
+        prerelease: false

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,190 @@
+# Releasing Reviewer
+
+## Quick Reference
+
+```bash
+# 1. Update version and changelog
+# 2. Commit and push
+git add -A && git commit -m "Release vX.Y.Z" && git push
+
+# 3. Tag and push
+git tag vX.Y.Z && git push origin vX.Y.Z
+
+# Done - automation handles the rest
+```
+
+## How It Works
+
+Releases are fully automated via GitHub Actions:
+
+1. **Branch protection** requires CI to pass before merging to `main`
+2. When you push a version tag, the release workflow:
+   - Validates the tag points to a commit on `main` (ensures CI passed)
+   - Builds and publishes the gem to RubyGems
+   - Creates a GitHub Release with changelog excerpt
+
+No redundant test runs. If it's on `main`, it already passed CI.
+
+## Release Steps
+
+### 1. Update Version
+
+Edit `lib/reviewer/version.rb`:
+
+```ruby
+VERSION = 'X.Y.Z'
+```
+
+### 2. Update CHANGELOG
+
+Move items from `[Unreleased]` to a new version section:
+
+```markdown
+## [Unreleased]
+
+## [X.Y.Z] - YYYY-MM-DD
+
+### Added
+- New feature description
+
+### Fixed
+- Bug fix description
+```
+
+### 3. Commit, Tag, Push
+
+```bash
+git add lib/reviewer/version.rb CHANGELOG.md
+git commit -m "Release vX.Y.Z"
+git push origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 4. Verify
+
+- Watch the [Actions tab](https://github.com/garrettdimon/reviewer/actions) for workflow completion
+- Check [RubyGems](https://rubygems.org/gems/reviewer) for the new version
+- Check [GitHub Releases](https://github.com/garrettdimon/reviewer/releases) for the release page
+
+## Versioning Policy
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **MAJOR** (x.0.0): Breaking changes to public API or configuration
+- **MINOR** (0.x.0): New features, deprecations
+- **PATCH** (0.0.x): Bug fixes, documentation
+
+### What's a Breaking Change?
+
+- Removing or renaming public classes/methods
+- Changing method signatures incompatibly
+- Changing default configuration behavior
+- Dropping Ruby version support
+
+## Local Tools
+
+### Full Preflight Check
+
+Run all checks before pushing:
+
+```bash
+bundle exec rake release:preflight
+```
+
+This runs tests, security audit, and release validation in sequence.
+
+### Individual Tasks
+
+| Task | Purpose |
+|------|---------|
+| `rake release:preflight` | Run all checks (test, audit, check) |
+| `rake release:check` | Validate version format, changelog entry, git state |
+| `rake release:audit` | Check for vulnerable dependencies |
+| `rake release:dry_run` | Build gem locally, show contents and size |
+| `rake test` | Run test suite |
+
+### Preview a Release
+
+Before tagging, preview what the gem will contain:
+
+```bash
+bundle exec rake release:dry_run
+```
+
+This builds the gem, displays its contents and size, then cleans up.
+
+## One-Time Setup
+
+### RubyGems Trusted Publishing
+
+1. Go to [rubygems.org/profile/oidc/pending_trusted_publishers](https://rubygems.org/profile/oidc/pending_trusted_publishers)
+2. Add trusted publisher:
+   - **Gem name:** `reviewer`
+   - **Repository owner:** `garrettdimon`
+   - **Repository name:** `reviewer`
+   - **Workflow filename:** `release.yml`
+   - **Environment:** `rubygems`
+
+### GitHub Environment
+
+1. Go to repository Settings > Environments
+2. Create environment named `rubygems`
+3. (Optional) Add required reviewers for extra safety
+
+### Repository Ruleset
+
+1. Go to repository Settings > Rules > Rulesets
+2. Edit the `main` ruleset (or create one targeting the default branch)
+3. Enable "Require status checks to pass" with these checks:
+   - `Security`
+   - `Test (Ruby 3.2)`
+   - `Test (Ruby 3.3)`
+   - `Test (Ruby 3.4)`
+   - `Test (Ruby 4.0)`
+   - `Changelog`
+   - `Version`
+
+## Troubleshooting
+
+### Release workflow fails with "must point to commit on main"
+
+You tagged a commit that isn't on the main branch. Delete the tag and re-tag a commit on main:
+
+```bash
+git tag -d vX.Y.Z              # Delete local tag
+git push origin :vX.Y.Z        # Delete remote tag
+git checkout main
+git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### "You do not have permission to push to this gem"
+
+The RubyGems trusted publisher isn't configured, or the environment name doesn't match. Check the one-time setup steps above.
+
+### Forgot to update CHANGELOG
+
+Delete the tag, update CHANGELOG, amend the commit, re-tag:
+
+```bash
+git tag -d vX.Y.Z
+git push origin :vX.Y.Z
+# Update CHANGELOG.md
+git add CHANGELOG.md
+git commit --amend --no-edit
+git push --force-with-lease origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+## Manual Release (Fallback)
+
+If automation fails and you need to publish manually:
+
+```bash
+bundle exec rake release
+```
+
+This builds the gem and pushes to RubyGems using your local credentials.

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,120 @@ Rake::TestTask.new(:test) do |t|
 end
 
 task default: :test
+
+# rubocop:disable Metrics/BlockLength
+namespace :release do
+  desc 'Run bundle-audit to check for vulnerable dependencies'
+  task :audit do
+    puts 'Running security audit...'
+    sh 'bundle exec bundle-audit check --update'
+  end
+
+  desc 'Validate version, changelog, and git state before release'
+  task :check do
+    require_relative 'lib/reviewer/version'
+    errors = ReleaseChecker.new(Reviewer::VERSION).validate
+    if errors.any?
+      puts "\nRelease check failed:"
+      errors.each { |e| puts "  - #{e}" }
+      exit 1
+    else
+      puts 'All release checks passed.'
+    end
+  end
+
+  desc 'Run all pre-release checks (tests, audit, release:check)'
+  task preflight: %i[test audit check] do
+    puts "\nAll preflight checks passed. Ready to release."
+  end
+
+  desc 'Build gem locally and show contents (dry run)'
+  task :dry_run do
+    require_relative 'lib/reviewer/version'
+    DryRun.new(Reviewer::VERSION).run
+  end
+end
+# rubocop:enable Metrics/BlockLength
+
+# Validates release readiness
+class ReleaseChecker
+  def initialize(version)
+    @version = version
+    @errors = []
+  end
+
+  def validate
+    puts "Checking release readiness for v#{@version}..."
+    check_version_format
+    check_changelog
+    check_git_clean
+    check_main_branch
+    @errors
+  end
+
+  private
+
+  def check_version_format
+    return if @version.match?(/\A\d+\.\d+\.\d+\z/)
+
+    @errors << "Version '#{@version}' is not valid semver (expected X.Y.Z)"
+  end
+
+  def check_changelog
+    changelog = File.read('CHANGELOG.md')
+    return if changelog.include?("[#{@version}]")
+
+    @errors << "CHANGELOG.md has no entry for version #{@version}"
+  end
+
+  def check_git_clean
+    return if `git status --porcelain`.empty?
+
+    @errors << 'Working directory has uncommitted changes'
+  end
+
+  def check_main_branch
+    current_branch = `git branch --show-current`.strip
+    return if current_branch == 'main'
+
+    @errors << "Not on main branch (currently on '#{current_branch}')"
+  end
+end
+
+# Builds gem and displays contents without publishing
+class DryRun
+  def initialize(version)
+    @version = version
+    @gem_file = "reviewer-#{version}.gem"
+  end
+
+  def run
+    build || abort('Gem build failed')
+    show_contents
+    show_size
+  ensure
+    cleanup if File.exist?(@gem_file)
+  end
+
+  private
+
+  def build
+    puts "Building #{@gem_file}..."
+    system 'gem build reviewer.gemspec --silent'
+  end
+
+  def show_contents
+    puts "\nGem contents:"
+    system "tar -tf #{@gem_file}"
+  end
+
+  def show_size
+    size = File.size(@gem_file)
+    puts "\nGem size: #{(size / 1024.0).round(1)} KB"
+  end
+
+  def cleanup
+    File.delete(@gem_file)
+    puts "Cleaned up #{@gem_file}"
+  end
+end


### PR DESCRIPTION
## Summary

This PR overhauls the release process to make it simpler, safer, and more automated. The goal is to minimize manual steps while ensuring every release is consistent and verified.

## What's New

### Automated Release Workflow

When you push a version tag (`v*`), GitHub Actions now:
1. Validates the tag points to a commit on `main` (ensuring CI already passed)
2. Builds and publishes the gem to RubyGems via trusted publishing
3. Creates a GitHub Release with the changelog excerpt

No redundant test runs—if code is on `main`, it already passed CI.

### Enhanced CI Checks

New validation jobs run on every push/PR:
- **Security** — dependency vulnerability audit
- **Test** — test suite across Ruby 3.2, 3.3, 3.4, and 4.0
- **Changelog** — validates format and `[Unreleased]` section exists
- **Version** — checks version/changelog consistency

### Local Tools

New rake tasks for release preparation:

| Task | Purpose |
|------|---------|
| `rake release:preflight` | Run all checks (test, audit, check) |
| `rake release:check` | Validate version, changelog, git state |
| `rake release:audit` | Check for vulnerable dependencies |
| `rake release:dry_run` | Preview gem contents and size |

### Documentation

Complete `RELEASING.md` with:
- Quick reference commands
- Step-by-step release process
- Versioning policy
- All available rake tasks
- One-time setup instructions (trusted publishing, repository ruleset)
- Troubleshooting guide

## Your New Release Flow

```bash
# Update version.rb and CHANGELOG.md, then:
git add -A && git commit -m "Release v1.0.0" && git push
git tag v1.0.0 && git push origin v1.0.0
# Done — automation handles the rest
```

## One-Time Setup Required

Before the first automated release:
1. Configure RubyGems trusted publishing
2. Create GitHub `rubygems` environment
3. Configure repository ruleset requiring CI checks

Details in `RELEASING.md`.

## Test Plan

- [x] All tests pass (234 tests, 475 assertions)
- [x] Security audit passes
- [x] `rake release:dry_run` works correctly
- [x] `rake release:check` validates correctly
- [x] Verify CI jobs run correctly on this PR