### PR TITLE
feat: add test file mapping for tools

### DIFF
--- a/.inch.yml
+++ b/.inch.yml
@@ -1,0 +1,6 @@
+files:
+  included:
+    - lib/**/*.rb
+  excluded:
+    # Data.define classes are not properly recognized by YARD/inch
+    - lib/reviewer/runner/result.rb

--- a/.reviewer.example.yml
+++ b/.reviewer.example.yml
@@ -23,6 +23,8 @@
 #  files:
 #    flag:                      // Optional, defaults to '' (empty string). The name of the flag used to pass subsets of files to the command.
 #    separator:                 // Optional, defaults to ' ' (single space). The character used to separate lists of files and directories.
+#    pattern:                   // Optional. Glob pattern to filter files (e.g., '*.rb'). Only files matching this pattern are passed to the tool.
+#    map_to_tests:              // Optional. Maps source files to test files. Values: 'minitest' (test/*_test.rb) or 'rspec' (spec/*_spec.rb).
 #  env:                         // Optional. A way to specify necessary environment variables for the tools commands. The key is the variable name, and the value is, well, the value.
 #    example_one: value         //           - The names will automatically be capitalized, so you can freely use lower-case here.
 #    example_one: value         //           - Reviewer is smart enough to handle string values with spaces and automatically quote them.
@@ -54,6 +56,8 @@ tool-name-key:
   files:
     flag: 'files'
     separator: ','
+    pattern: '*.rb'
+    map_to_tests: minitest
   env:
     report: false
   flags:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     csv (3.3.5)
+    date (3.5.1)
     debride (1.14.0)
       path_expander (~> 2.0)
       prism (~> 1.5)
@@ -94,6 +95,7 @@ GEM
       dry-inflector (~> 1.0)
       dry-logic (~> 1.4)
       zeitwerk (~> 2.6)
+    erb (6.0.1)
     erubi (1.13.1)
     erubis (2.7.0)
     fasterer (0.11.0)
@@ -169,6 +171,9 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     pstore (0.2.0)
+    psych (5.3.1)
+      date
+      stringio
     public_suffix (7.0.0)
     racc (1.8.1)
     rails_best_practices (1.23.3)
@@ -181,6 +186,10 @@ GEM
       ruby-progressbar
     rainbow (3.1.1)
     rake (13.3.1)
+    rdoc (7.1.0)
+      erb
+      psych (>= 4.0.0)
+      tsort
     readline (0.0.4)
       reline
     redcard (1.1.0)
@@ -262,6 +271,7 @@ GEM
     standard-performance (1.9.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.26.0)
+    stringio (3.2.0)
     sync (0.5.0)
     term-ansicolor (1.11.3)
       tins (~> 1)
@@ -273,6 +283,7 @@ GEM
       readline
       sync
     tomlrb (2.0.4)
+    tsort (0.2.0)
     tty-which (0.5.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -310,6 +321,7 @@ DEPENDENCIES
   minitest-heat
   racc
   rake (~> 13.2)
+  rdoc
   reek
   reviewer!
   rubocop

--- a/lib/reviewer/arguments.rb
+++ b/lib/reviewer/arguments.rb
@@ -19,6 +19,8 @@ module Reviewer
   #   `rvw ruby staged`
   #
   class Arguments
+    # @!attribute options
+    #   @return [Slop::Result] the parsed command-line options
     attr_accessor :options
 
     attr_reader :output

--- a/lib/reviewer/arguments/tags.rb
+++ b/lib/reviewer/arguments/tags.rb
@@ -4,6 +4,10 @@ module Reviewer
   class Arguments
     # Handles the logic of translating tag arguments
     class Tags
+      # @!attribute provided
+      #   @return [Array<String>] tags explicitly provided via -t or --tags flag
+      # @!attribute keywords
+      #   @return [Array<String>] tags derived from keyword arguments
       attr_accessor :provided, :keywords
 
       alias raw provided

--- a/lib/reviewer/command/string.rb
+++ b/lib/reviewer/command/string.rb
@@ -11,12 +11,21 @@ module Reviewer
 
       attr_reader :command_type, :tool_settings, :files
 
+      # Creates a command string builder for a tool
+      # @param command_type [Symbol] the command type (:install, :prepare, :review, :format)
+      # @param tool_settings [Tool::Settings] the tool's configuration settings
+      # @param files [Array<String>] files to include in the command
+      #
+      # @return [String] a command string builder instance
       def initialize(command_type, tool_settings:, files: [])
         @command_type = command_type
         @tool_settings = tool_settings
         @files = Array(files)
       end
 
+      # Converts the command to a complete string ready for execution
+      #
+      # @return [String] the full command string
       def to_s
         to_a
           .map(&:strip) # Remove extra spaces on the components
@@ -24,6 +33,9 @@ module Reviewer
           .strip        # Strip extra spaces from the end result
       end
 
+      # Converts the command to an array of its components
+      #
+      # @return [Array<String, nil>] env vars, body, flags, and files
       def to_a
         [
           env_variables,
@@ -38,6 +50,9 @@ module Reviewer
       # @return [String] the environment variable names and values concatened for the command
       def env_variables = Env.new(tool_settings.env).to_s
 
+      # The base command string from the tool's configuration
+      #
+      # @return [String] the configured command for the command type
       def body = tool_settings.commands.fetch(command_type)
 
       # Gets the flags to be used in conjunction with the review command for a tool

--- a/lib/reviewer/command/string/env.rb
+++ b/lib/reviewer/command/string/env.rb
@@ -15,10 +15,16 @@ module Reviewer
           @env_pairs = env_pairs
         end
 
+        # Converts environment variables to a space-separated string
+        #
+        # @return [String] formatted environment variables (e.g., "KEY=value KEY2=value2")
         def to_s
           to_a.compact.join(' ')
         end
 
+        # Converts environment variables to an array of KEY=value strings
+        #
+        # @return [Array<String, nil>] array of formatted env vars, nil for empty values
         def to_a
           env_pairs.map { |key, value| env(key, value) }
         end

--- a/lib/reviewer/configuration.rb
+++ b/lib/reviewer/configuration.rb
@@ -9,6 +9,8 @@ module Reviewer
   #   @return [Pathname] the pathname for the primary configuraton file
   # @!attribute history_file
   #   @return [Pathname] the pathname for the history file to store data across runs
+  # @!attribute printer
+  #   @return [Output::Printer] the printer instance for console output
   #
   # @author [garrettdimon]
   #

--- a/lib/reviewer/keywords/git.rb
+++ b/lib/reviewer/keywords/git.rb
@@ -4,22 +4,39 @@ module Reviewer
   module Keywords
     # Git-based file list commands
     module Git
+      # Returns files staged for commit
+      #
+      # @return [Array<String>] list of staged file paths
       def self.staged
         run(%w[diff --staged --name-only])
       end
 
+      # Returns files with unstaged changes
+      #
+      # @return [Array<String>] list of modified but unstaged file paths
       def self.unstaged
         run(%w[diff --name-only])
       end
 
+      # Returns all modified files (staged and unstaged)
+      #
+      # @return [Array<String>] list of all modified file paths
       def self.modified
         run(%w[diff --name-only HEAD])
       end
 
+      # Returns untracked files not in .gitignore
+      #
+      # @return [Array<String>] list of untracked file paths
       def self.untracked
         run(%w[ls-files --others --exclude-standard])
       end
 
+      # Executes a git command and returns the output as an array of lines
+      # @param options [Array<String>] the git command options
+      #
+      # @return [Array<String>] the output lines from the command
+      # @raise [SystemCallError] if the git command fails
       def self.run(options)
         command = (%w[git --no-pager] + options).join(' ')
         stdout, stderr, status = Open3.capture3(command)

--- a/lib/reviewer/loader.rb
+++ b/lib/reviewer/loader.rb
@@ -13,6 +13,13 @@ module Reviewer
 
     attr_reader :configuration, :file
 
+    # Creates a loader instance for the configuration file
+    # @param file [Pathname] the path to the configuration YAML file
+    #
+    # @return [Loader] a loader with parsed configuration
+    # @raise [MissingConfigurationError] if the file doesn't exist
+    # @raise [InvalidConfigurationError] if the YAML is malformed
+    # @raise [MissingReviewCommandError] if a tool lacks a review command
     def initialize(file = Reviewer.configuration.file)
       @file = file
       @configuration = configuration_hash
@@ -20,8 +27,14 @@ module Reviewer
       validate_configuration!
     end
 
+    # Converts the loader to its configuration hash
+    #
+    # @return [Hash] the parsed configuration
     def to_h = configuration
 
+    # Loads and returns the tools configuration hash
+    #
+    # @return [Hash] the parsed configuration from the YAML file
     def self.configuration = new.configuration
 
     private

--- a/lib/reviewer/output.rb
+++ b/lib/reviewer/output.rb
@@ -26,9 +26,19 @@ module Reviewer
       @printer = printer
     end
 
+    # Clears the console screen
+    #
+    # @return [Boolean, nil] result of system call
     def clear = system('clear')
+
+    # Prints an empty line
+    #
+    # @return [void]
     def newline = printer.puts(:default, '')
 
+    # Prints a horizontal divider line
+    #
+    # @return [void]
     def divider
       newline
       printer.print(:muted, DIVIDER * console_width)
@@ -74,6 +84,10 @@ module Reviewer
       printer.puts(:default, String(command))
     end
 
+    # Prints a success message with timing information
+    # @param timer [Shell::Timer] the timer with execution times
+    #
+    # @return [void]
     def success(timer)
       printer.print(:success, 'Success')
       printer.print(:success_light, " #{timer.total_seconds}s")
@@ -82,12 +96,21 @@ module Reviewer
       newline
     end
 
+    # Prints a skipped message with the reason
+    # @param reason [String] why the tool was skipped
+    #
+    # @return [void]
     def skipped(reason = 'no matching files')
       printer.print(:muted, 'Skipped')
       printer.puts(:muted, " (#{reason})")
       newline
     end
 
+    # Prints a failure message with details and optionally the failed command
+    # @param details [String] the failure details
+    # @param command [String, Command, nil] the command that failed
+    #
+    # @return [void]
     def failure(details, command: nil)
       printer.print(:failure, 'Failure')
       printer.puts(:muted, " #{details}")
@@ -99,11 +122,20 @@ module Reviewer
       printer.puts(:muted, String(command))
     end
 
+    # Prints an unrecoverable error message
+    # @param details [String] the error details to display
+    #
+    # @return [void]
     def unrecoverable(details)
       printer.puts(:error, 'Unrecoverable Error:')
       printer.puts(:muted, details)
     end
 
+    # Prints guidance information to help users resolve issues
+    # @param summary [String] the bold summary line
+    # @param details [String, nil] the detailed guidance text
+    #
+    # @return [void]
     def guidance(summary, details)
       return if details.nil?
 
@@ -112,6 +144,10 @@ module Reviewer
       printer.puts(:muted, details)
     end
 
+    # Outputs raw content directly to the stream without styling
+    # @param value [String, nil] the content to output
+    #
+    # @return [void]
     def unfiltered(value)
       return if value.nil? || value.strip.empty?
 

--- a/lib/reviewer/output/printer.rb
+++ b/lib/reviewer/output/printer.rb
@@ -16,10 +16,20 @@ module Reviewer
         end
       end
 
+      # Prints styled content without a newline
+      # @param style [Symbol] the style key for color and weight
+      # @param content [String] the text to print
+      #
+      # @return [void]
       def print(style, content)
         text(style, content)
       end
 
+      # Prints styled content followed by a newline
+      # @param style [Symbol] the style key for color and weight
+      # @param content [String] the text to print
+      #
+      # @return [void]
       def puts(style, content)
         text(style, content)
         stream.puts

--- a/lib/reviewer/output/token.rb
+++ b/lib/reviewer/output/token.rb
@@ -9,13 +9,25 @@ module Reviewer
     class Token
       ESC = "\e["
 
+      # @!attribute style
+      #   @return [Symbol] the style key (e.g., :success, :failure, :muted)
+      # @!attribute content
+      #   @return [String] the text content to display
       attr_accessor :style, :content
 
+      # Creates a styled output token
+      # @param style [Symbol] the style key for color and weight
+      # @param content [String] the text content to display
+      #
+      # @return [Token] a styled token instance
       def initialize(style, content)
         @style = style
         @content = content
       end
 
+      # Converts the token to an ANSI-styled string
+      #
+      # @return [String] the content wrapped in ANSI escape codes
       def to_s
         [
           style_string,

--- a/lib/reviewer/report/formatter.rb
+++ b/lib/reviewer/report/formatter.rb
@@ -9,11 +9,19 @@ module Reviewer
 
       attr_reader :report, :output
 
+      # Creates a formatter for displaying a report
+      # @param report [Report] the report to format
+      # @param output [Output] the output handler for console display
+      #
+      # @return [Formatter] a formatter instance
       def initialize(report, output: Output.new)
         @report = report
         @output = output
       end
 
+      # Prints the formatted report to the console
+      #
+      # @return [void]
       def print
         if report.results.empty?
           output.printer.puts(:muted, 'No tools to run')

--- a/lib/reviewer/runner.rb
+++ b/lib/reviewer/runner.rb
@@ -9,6 +9,8 @@ module Reviewer
   class Runner
     extend Forwardable
 
+    # @!attribute strategy
+    #   @return [Class] the strategy class for running the command (Captured or Passthrough)
     attr_accessor :strategy
 
     attr_reader :command, :shell, :output
@@ -34,6 +36,9 @@ module Reviewer
       @output = output
     end
 
+    # Executes the command and returns the exit status
+    #
+    # @return [Integer] the exit status from the command
     def run
       # Skip if files were requested but none match this tool's pattern
       if command.skip?

--- a/lib/reviewer/runner/result.rb
+++ b/lib/reviewer/runner/result.rb
@@ -3,6 +3,27 @@
 module Reviewer
   class Runner
     # Immutable value object representing the result of running a single tool
+    #
+    # @!attribute [r] tool_key
+    #   @return [Symbol] the unique identifier for the tool
+    # @!attribute [r] tool_name
+    #   @return [String] the human-readable name of the tool
+    # @!attribute [r] command_type
+    #   @return [Symbol] the type of command run (:review, :format, etc.)
+    # @!attribute [r] command_string
+    #   @return [String] the full command string that was executed
+    # @!attribute [r] success
+    #   @return [Boolean] whether the command completed successfully
+    # @!attribute [r] exit_status
+    #   @return [Integer] the exit status code from the command
+    # @!attribute [r] duration
+    #   @return [Float] the execution time in seconds
+    # @!attribute [r] stdout
+    #   @return [String, nil] the standard output from the command
+    # @!attribute [r] stderr
+    #   @return [String, nil] the standard error from the command
+    # @!attribute [r] skipped
+    #   @return [Boolean] whether the tool was skipped
     Result = Data.define(
       :tool_key,
       :tool_name,

--- a/lib/reviewer/shell.rb
+++ b/lib/reviewer/shell.rb
@@ -34,7 +34,16 @@ module Reviewer
       result.exit_status = system(command) ? 0 : 1
     end
 
+    # Captures and times the preparation command execution
+    # @param command [String, Command] the command to run
+    #
+    # @return [Result] the captured result including stdout, stderr, and exit status
     def capture_prep(command) = timer.record_prep { capture_results(command) }
+
+    # Captures and times the main command execution
+    # @param command [String, Command] the command to run
+    #
+    # @return [Result] the captured result including stdout, stderr, and exit status
     def capture_main(command) = timer.record_main { capture_results(command) }
 
     private

--- a/lib/reviewer/shell/result.rb
+++ b/lib/reviewer/shell/result.rb
@@ -18,6 +18,14 @@ module Reviewer
         executable_not_found: "can't find executable"
       }.freeze
 
+      # @!attribute stdout
+      #   @return [String, nil] standard output from the command
+      # @!attribute stderr
+      #   @return [String, nil] standard error from the command
+      # @!attribute status
+      #   @return [Process::Status, nil] the process status object
+      # @!attribute exit_status
+      #   @return [Integer, nil] the exit status code from the command
       attr_accessor :stdout, :stderr, :status, :exit_status
 
       # An instance of a result from running a local command. Captures the values for `$stdout`,

--- a/lib/reviewer/shell/timer.rb
+++ b/lib/reviewer/shell/timer.rb
@@ -6,6 +6,10 @@ module Reviewer
   class Shell
     # Provides a structured interface for measuring realtime main while running comamnds
     class Timer
+      # @!attribute prep
+      #   @return [Float, nil] the preparation time in seconds
+      # @!attribute main
+      #   @return [Float, nil] the main execution time in seconds
       attr_accessor :prep, :main
 
       # A 'Smart' timer that understands preparation time and main time and can easily do the math
@@ -32,12 +36,31 @@ module Reviewer
       # @return [Float] the execution time for the main command
       def record_main(&) = @main = record(&)
 
+      # The preparation time rounded to two decimal places
+      #
+      # @return [Float] prep time in seconds
       def prep_seconds = prep.round(2)
+
+      # The main execution time rounded to two decimal places
+      #
+      # @return [Float] main time in seconds
       def main_seconds = main.round(2)
+
+      # The total execution time (prep + main) rounded to two decimal places
+      #
+      # @return [Float] total time in seconds
       def total_seconds = total.round(2)
+
+      # The total time (prep + main) without rounding
+      #
+      # @return [Float] total time in seconds
       def total = [prep, main].compact.sum
+
       def prepped? = !(prep.nil? || main.nil?)
 
+      # The percentage of total time spent on preparation
+      #
+      # @return [Integer, nil] percentage (0-100) or nil if not prepped
       def prep_percent
         return nil unless prepped?
 

--- a/lib/reviewer/tool/file_resolver.rb
+++ b/lib/reviewer/tool/file_resolver.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Reviewer
+  class Tool
+    # Resolves which files a tool should process by mapping and filtering.
+    class FileResolver
+      # Creates a FileResolver for a tool's settings
+      # @param settings [Tool::Settings] the tool's settings containing file configuration
+      #
+      # @return [FileResolver] a resolver instance for the tool
+      def initialize(settings)
+        @settings = settings
+      end
+
+      # Resolves input files by mapping source files to test files (if configured) and
+      # filtering by the tool's file pattern
+      # @param files [Array<String>] the input files to resolve
+      #
+      # @return [Array<String>] files after mapping and filtering
+      def resolve(files)
+        return files unless pattern
+
+        filter(map(files))
+      end
+
+      # Determines if the tool should be skipped because files were requested but none match
+      # @param files [Array<String>] the requested files
+      #
+      # @return [Boolean] true if files were requested but none remain after resolution
+      def skip?(files)
+        files.any? && resolve(files).empty?
+      end
+
+      private
+
+      attr_reader :settings
+
+      def map(files)
+        return files unless settings.map_to_tests
+
+        TestFileMapper.new(settings.map_to_tests).map(files)
+      end
+
+      def filter(files)
+        files.select { |file| File.fnmatch(pattern, File.basename(file)) }
+      end
+
+      def pattern
+        settings.files_pattern
+      end
+    end
+  end
+end

--- a/lib/reviewer/tool/settings.rb
+++ b/lib/reviewer/tool/settings.rb
@@ -18,6 +18,9 @@ module Reviewer
         @config = config || load_config
       end
 
+      # Returns a hash code for comparing settings instances
+      #
+      # @return [Integer] hash code based on configuration state
       def hash = state.hash
 
       def eql?(other)
@@ -29,16 +32,56 @@ module Reviewer
       def disabled? = config.fetch(:disabled) { false }
       def enabled? = !disabled?
 
+      # The human-readable name of the tool
+      #
+      # @return [String] the configured name or capitalized tool key
       def name = config.fetch(:name) { tool_key.to_s.capitalize }
+
+      # The human-readable description of what the tool does
+      #
+      # @return [String] the configured description or a default placeholder
       def description = config.fetch(:description) { "(No description provided for '#{name}')" }
+
+      # The tags used to categorize and filter the tool
+      #
+      # @return [Array<String>] configured tags or empty array
       def tags = config.fetch(:tags) { [] }
+
+      # The collection of reference links for the tool (home, install, usage, etc.)
+      #
+      # @return [Hash] configured links or empty hash if none
       def links = config.fetch(:links) { {} }
+
+      # The environment variables to set when running the tool
+      #
+      # @return [Hash] configured env vars or empty hash
       def env = config.fetch(:env) { {} }
+
+      # The CLI flags to pass to the tool's review command
+      #
+      # @return [Hash] configured flags or empty hash
       def flags = config.fetch(:flags) { {} }
 
+      # The CLI flag used to pass files to the tool (e.g., '--files')
+      #
+      # @return [String] the configured flag or empty string if files are passed directly
       def files_flag = config.dig(:files, :flag) || ''
+
+      # The separator used to join multiple file paths in the command
+      #
+      # @return [String] the configured separator or a space by default
       def files_separator = config.dig(:files, :separator) || ' '
+
+      # The glob pattern used to filter which files this tool should process
+      #
+      # @return [String, nil] the pattern (e.g., '*.rb') or nil if not configured
       def files_pattern = config.dig(:files, :pattern)
+
+      # The test framework to use for mapping source files to test files
+      #
+      # @return [String, nil] the framework name ('minitest' or 'rspec') or nil if not configured
+      def map_to_tests = config.dig(:files, :map_to_tests)
+
       def supports_files? = config.key?(:files)
 
       # The collection of configured commands for the tool

--- a/lib/reviewer/tool/test_file_mapper.rb
+++ b/lib/reviewer/tool/test_file_mapper.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+module Reviewer
+  class Tool
+    # Maps source files to their corresponding test files based on framework conventions.
+    class TestFileMapper
+      FRAMEWORKS = {
+        minitest: { dir: 'test', suffix: '_test.rb', source_dirs: %w[app lib] },
+        rspec: { dir: 'spec', suffix: '_spec.rb', source_dirs: %w[app lib] }
+      }.freeze
+
+      # Creates a mapper for the specified test framework
+      # @param framework [Symbol, String, nil] the test framework (:minitest or :rspec)
+      #
+      # @return [TestFileMapper] a mapper instance for the framework
+      def initialize(framework)
+        @framework = framework&.to_sym
+      end
+
+      # Maps source files to their corresponding test files
+      # @param files [Array<String>] source files to map
+      #
+      # @return [Array<String>] mapped test files (only those that exist on disk)
+      def map(files)
+        return files unless supported?
+
+        files.map { |f| map_file(f) }.compact.uniq
+      end
+
+      # Checks if the framework is supported for mapping
+      #
+      # @return [Boolean] true if the framework is :minitest or :rspec
+      def supported?
+        @framework && FRAMEWORKS.key?(@framework)
+      end
+
+      private
+
+      def map_file(file)
+        return file if test_file?(file)
+
+        mapped = source_to_test(file)
+        mapped && File.exist?(mapped) ? mapped : nil
+      end
+
+      def test_file?(file)
+        file.end_with?(config[:suffix])
+      end
+
+      def source_to_test(file)
+        return nil unless file.end_with?('.rb')
+
+        replace_source_dir_with_test_dir(file).sub(/\.rb$/, config[:suffix])
+      end
+
+      def replace_source_dir_with_test_dir(path)
+        config[:source_dirs].each do |dir|
+          return path.sub(%r{^#{dir}/}, "#{config[:dir]}/") if path.start_with?("#{dir}/")
+        end
+        prepend_test_dir(path)
+      end
+
+      def prepend_test_dir(path)
+        path.start_with?(config[:dir]) ? path : "#{config[:dir]}/#{path}"
+      end
+
+      def config
+        FRAMEWORKS[@framework]
+      end
+    end
+  end
+end

--- a/reviewer.gemspec
+++ b/reviewer.gemspec
@@ -38,6 +38,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-heat'
+  spec.add_development_dependency 'rdoc'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'simplecov_json_formatter'
   spec.add_development_dependency 'yard'

--- a/test/fixtures/files/test_commands.yml
+++ b/test/fixtures/files/test_commands.yml
@@ -141,3 +141,14 @@ test_pattern_tool:
     flag: ''
     separator: ' '
     pattern: '*_test.rb'
+
+# For Testing Test File Mapping (source to test)
+test_mapping_tool:
+  disabled: true
+  commands:
+    review: 'rake test'
+  files:
+    flag: ''
+    separator: ' '
+    pattern: '*_test.rb'
+    map_to_tests: minitest

--- a/test/reviewer/tool/file_resolver_test.rb
+++ b/test/reviewer/tool/file_resolver_test.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Reviewer
+  class Tool
+    class FileResolverTest < Minitest::Test
+      def test_returns_files_unchanged_when_no_pattern_configured
+        settings = build_settings(files: nil)
+        resolver = FileResolver.new(settings)
+
+        result = resolver.resolve(['app/models/user.rb', 'lib/tool.rb'])
+
+        assert_equal ['app/models/user.rb', 'lib/tool.rb'], result
+      end
+
+      def test_filters_files_by_pattern
+        settings = build_settings(files: { pattern: '*.rb' })
+        resolver = FileResolver.new(settings)
+
+        result = resolver.resolve(['app/models/user.rb', 'app/assets/app.js', 'lib/tool.rb'])
+
+        assert_equal ['app/models/user.rb', 'lib/tool.rb'], result
+      end
+
+      def test_maps_source_files_to_test_files_when_configured
+        settings = build_settings(files: { pattern: '*_test.rb', map_to_tests: 'minitest' })
+        resolver = FileResolver.new(settings)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test/models')
+            FileUtils.touch('test/models/user_test.rb')
+
+            result = resolver.resolve(['app/models/user.rb'])
+
+            assert_equal ['test/models/user_test.rb'], result
+          end
+        end
+      end
+
+      def test_passes_through_test_files_unchanged_when_mapping_configured
+        settings = build_settings(files: { pattern: '*_test.rb', map_to_tests: 'minitest' })
+        resolver = FileResolver.new(settings)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test/models')
+            FileUtils.touch('test/models/user_test.rb')
+
+            result = resolver.resolve(['test/models/user_test.rb'])
+
+            assert_equal ['test/models/user_test.rb'], result
+          end
+        end
+      end
+
+      def test_returns_empty_when_mapped_test_does_not_exist
+        settings = build_settings(files: { pattern: '*_test.rb', map_to_tests: 'minitest' })
+        resolver = FileResolver.new(settings)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            # No test file exists
+            result = resolver.resolve(['app/models/user.rb'])
+
+            assert_empty result
+          end
+        end
+      end
+
+      def test_skip_returns_true_when_files_requested_but_none_match
+        settings = build_settings(files: { pattern: '*.rb' })
+        resolver = FileResolver.new(settings)
+
+        assert resolver.skip?(['app.js', 'style.css'])
+      end
+
+      def test_skip_returns_false_when_no_files_requested
+        settings = build_settings(files: { pattern: '*.rb' })
+        resolver = FileResolver.new(settings)
+
+        refute resolver.skip?([])
+      end
+
+      def test_skip_returns_false_when_files_match_pattern
+        settings = build_settings(files: { pattern: '*.rb' })
+        resolver = FileResolver.new(settings)
+
+        refute resolver.skip?(['app/models/user.rb'])
+      end
+
+      private
+
+      def build_settings(files:)
+        config = { commands: { review: 'test' } }
+        config[:files] = files if files
+        Settings.new(:test_tool, config: config)
+      end
+    end
+  end
+end

--- a/test/reviewer/tool/settings_test.rb
+++ b/test/reviewer/tool/settings_test.rb
@@ -140,6 +140,14 @@ module Reviewer
         @settings = Settings.new(@tool, config: @config)
         assert_equal '*.rb', @settings.files_pattern
       end
+
+      def test_provides_map_to_tests_with_nil_as_default
+        assert_nil @settings.map_to_tests
+
+        @config[:files] = { flag: '', separator: ' ', pattern: '*_test.rb', map_to_tests: 'minitest' }
+        @settings = Settings.new(@tool, config: @config)
+        assert_equal 'minitest', @settings.map_to_tests
+      end
     end
   end
 end

--- a/test/reviewer/tool/test_file_mapper_test.rb
+++ b/test/reviewer/tool/test_file_mapper_test.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Reviewer
+  class Tool
+    class TestFileMapperTest < Minitest::Test
+      def test_recognizes_minitest_framework
+        mapper = TestFileMapper.new(:minitest)
+        assert mapper.supported?
+      end
+
+      def test_recognizes_rspec_framework
+        mapper = TestFileMapper.new(:rspec)
+        assert mapper.supported?
+      end
+
+      def test_returns_unsupported_for_unknown_framework
+        mapper = TestFileMapper.new(:unknown)
+        refute mapper.supported?
+      end
+
+      def test_returns_unsupported_for_nil_framework
+        mapper = TestFileMapper.new(nil)
+        refute mapper.supported?
+      end
+
+      def test_maps_app_model_to_test_for_minitest
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test/models')
+            FileUtils.touch('test/models/user_test.rb')
+
+            result = mapper.map(['app/models/user.rb'])
+            assert_equal ['test/models/user_test.rb'], result
+          end
+        end
+      end
+
+      def test_maps_lib_file_to_spec_for_rspec
+        mapper = TestFileMapper.new(:rspec)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('spec/reviewer')
+            FileUtils.touch('spec/reviewer/tool_spec.rb')
+
+            result = mapper.map(['lib/reviewer/tool.rb'])
+            assert_equal ['spec/reviewer/tool_spec.rb'], result
+          end
+        end
+      end
+
+      def test_passes_through_existing_test_files_unchanged
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test/models')
+            FileUtils.touch('test/models/user_test.rb')
+
+            result = mapper.map(['test/models/user_test.rb'])
+            assert_equal ['test/models/user_test.rb'], result
+          end
+        end
+      end
+
+      def test_returns_empty_for_nonexistent_test_file
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            result = mapper.map(['app/models/user.rb'])
+            assert_empty result
+          end
+        end
+      end
+
+      def test_handles_file_without_app_or_lib_prefix
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test')
+            FileUtils.touch('test/standalone_test.rb')
+
+            result = mapper.map(['standalone.rb'])
+            assert_equal ['test/standalone_test.rb'], result
+          end
+        end
+      end
+
+      def test_returns_files_unchanged_for_unsupported_framework
+        mapper = TestFileMapper.new(:unknown)
+        files = ['app/models/user.rb', 'lib/tool.rb']
+
+        result = mapper.map(files)
+        assert_equal files, result
+      end
+
+      def test_deduplicates_mapped_files
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            FileUtils.mkdir_p('test/models')
+            FileUtils.touch('test/models/user_test.rb')
+
+            result = mapper.map(['app/models/user.rb', 'app/models/user.rb'])
+            assert_equal ['test/models/user_test.rb'], result
+          end
+        end
+      end
+
+      def test_handles_string_framework_name
+        mapper = TestFileMapper.new('minitest')
+        assert mapper.supported?
+      end
+
+      def test_excludes_non_ruby_files
+        mapper = TestFileMapper.new(:minitest)
+
+        Dir.mktmpdir do |dir|
+          Dir.chdir(dir) do
+            result = mapper.map(['app/assets/application.js'])
+            assert_empty result
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/reviewer/tool_test.rb
+++ b/test/reviewer/tool_test.rb
@@ -84,5 +84,31 @@ module Reviewer
       assert @tool.formattable?
       refute @mvt.formattable?
     end
+
+    def test_resolve_files_delegates_to_file_resolver
+      tool = Tool.new(:file_pattern_tool)
+
+      result = tool.resolve_files(['app/models/user.rb', 'app.js'])
+
+      assert_equal ['app/models/user.rb'], result
+    end
+
+    def test_resolve_files_returns_files_unchanged_when_no_pattern
+      result = @tool.resolve_files(['app/models/user.rb', 'app.js'])
+
+      assert_equal ['app/models/user.rb', 'app.js'], result
+    end
+
+    def test_skip_files_returns_true_when_files_requested_but_none_match
+      tool = Tool.new(:file_pattern_tool)
+
+      assert tool.skip_files?(['app.js', 'style.css'])
+    end
+
+    def test_skip_files_returns_false_when_no_files_requested
+      tool = Tool.new(:file_pattern_tool)
+
+      refute tool.skip_files?([])
+    end
   end
 end


### PR DESCRIPTION
## Summary

Adds the ability to map source files to their corresponding test files when running tools. This lets you run `rvw tests -f lib/reviewer/tool.rb` and have it automatically find and run `test/reviewer/tool_test.rb`.

## Configuration

Add `map_to_tests` to a tool's files configuration:

```yaml
tests:
  commands:
    review: "bundle exec rake"
  files:
    pattern: '*_test.rb'
    map_to_tests: minitest  # or 'rspec'
```

## Behavior

- Source files (`app/` or `lib/`) are mapped to test files (`test/` or `spec/`)
- Test files pass through unchanged
- Files without existing tests are skipped (no errors)
- Works with `staged`, `modified`, and `-f` file arguments

## Changes

- Extracted file resolution from Command to Tool::FileResolver
- Added Tool::TestFileMapper for source-to-test mapping
- Updated example config documentation