### PR TITLE
Fix README Ruby version to 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Or add to your Gemfile:
 gem 'reviewer'
 ```
 
-**Requires Ruby 3.0+**
+**Requires Ruby 3.2+**
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

- Updates README to show Ruby 3.2+ requirement, matching the gemspec and CI configuration