### PR TITLE
Add `failed` keyword to re-run failed tools

### DIFF
--- a/lib/reviewer/arguments/keywords.rb
+++ b/lib/reviewer/arguments/keywords.rb
@@ -8,7 +8,7 @@ module Reviewer
     # @!attribute provided
     #   @return [Array<String>] the keywords extracted from the command-line arguments
     class Keywords
-      RESERVED = %w[staged unstaged modified untracked].freeze
+      RESERVED = %w[staged unstaged modified untracked failed].freeze
 
       attr_accessor :provided
 
@@ -48,6 +48,11 @@ module Reviewer
         }
       end
       alias inspect to_h
+
+      # Whether the `failed` keyword was provided
+      #
+      # @return [Boolean] true if the `failed` keyword is present
+      def failed? = provided.include?('failed')
 
       # Extracts reserved keywords from the provided arguments
       #

--- a/lib/reviewer/command.rb
+++ b/lib/reviewer/command.rb
@@ -41,7 +41,11 @@ module Reviewer
     #
     # @return [Integer] a random integer to pass to tools that use seeds
     def seed
-      @seed ||= Random.rand(100_000)
+      @seed ||= if Reviewer.arguments.keywords.failed?
+                  Reviewer.history.get(tool.key, :last_seed) || Random.rand(100_000)
+                else
+                  Random.rand(100_000)
+                end
 
       # Store the seed for reference
       Reviewer.history.set(tool.key, :last_seed, @seed)

--- a/lib/reviewer/output.rb
+++ b/lib/reviewer/output.rb
@@ -131,6 +131,20 @@ module Reviewer
       printer.puts(:muted, details)
     end
 
+    # Prints a message when `rvw failed` is used but no tools failed in the last run
+    #
+    # @return [void]
+    def no_failures_to_retry
+      printer.puts(:muted, 'No failures to retry')
+    end
+
+    # Prints a message when `rvw failed` is used but no previous run exists
+    #
+    # @return [void]
+    def no_previous_run
+      printer.puts(:muted, 'No previous run found')
+    end
+
     # Prints guidance information to help users resolve issues
     # @param summary [String] the bold summary line
     # @param details [String, nil] the detailed guidance text

--- a/lib/reviewer/shell/timer.rb
+++ b/lib/reviewer/shell/timer.rb
@@ -28,13 +28,13 @@ module Reviewer
       # @param &block [Block] the commands to be timed
       #
       # @return [Float] the execution time for the preparation
-      def record_prep(&block) = @prep = record(&block)
+      def record_prep(&) = @prep = record(&)
 
       # Records the execution time for the block and assigns it to the `main` time
       # @param &block [Block] the commands to be timed
       #
       # @return [Float] the execution time for the main command
-      def record_main(&block) = @main = record(&block)
+      def record_main(&) = @main = record(&)
 
       # The preparation time rounded to two decimal places
       #
@@ -69,7 +69,7 @@ module Reviewer
 
       private
 
-      def record(&block) = Benchmark.realtime(&block)
+      def record(&) = Benchmark.realtime(&)
     end
   end
 end

--- a/test/reviewer/arguments/keywords_test.rb
+++ b/test/reviewer/arguments/keywords_test.rb
@@ -90,6 +90,21 @@ module Reviewer
         assert_equal keywords.configured_tool_names.size, (keywords.possible & keywords.configured_tool_names).size
       end
 
+      def test_failed_is_a_reserved_keyword
+        assert_includes Keywords::RESERVED, 'failed'
+
+        keywords = Keywords.new('failed')
+        assert_includes keywords.reserved, 'failed'
+        assert_includes keywords.recognized, 'failed'
+        assert_includes keywords.possible, 'failed'
+      end
+
+      def test_failed_predicate
+        assert Keywords.new('failed').failed?
+        refute Keywords.new('staged').failed?
+        refute Keywords.new.failed?
+      end
+
       def test_exposes_recognized_and_unrecognized_keywords
         unrecognized_keywords = ['unrecognized']
         keywords = Keywords.new(Keywords::RESERVED + unrecognized_keywords)

--- a/test/reviewer/command_test.rb
+++ b/test/reviewer/command_test.rb
@@ -24,6 +24,38 @@ module Reviewer
       assert_match(/#{command.seed}/, command.string)
     end
 
+    def test_uses_stored_seed_when_failed_keyword_present
+      # Store a known seed
+      Reviewer.history.set(:dynamic_seed_tool, :last_seed, 42_424)
+      Reviewer.instance_variable_set(:@arguments, Arguments.new(%w[failed]))
+
+      command = Reviewer::Command.new(:dynamic_seed_tool, :review)
+      assert_equal 42_424, command.seed
+    ensure
+      Reviewer.history.set(:dynamic_seed_tool, :last_seed, nil)
+      Reviewer.reset!
+      ensure_test_configuration!
+    end
+
+    def test_generates_new_seed_when_failed_keyword_absent
+      Reviewer.history.set(:dynamic_seed_tool, :last_seed, 42_424)
+
+      command = Reviewer::Command.new(:dynamic_seed_tool, :review)
+      refute_equal 42_424, command.seed
+    ensure
+      Reviewer.history.set(:dynamic_seed_tool, :last_seed, nil)
+    end
+
+    def test_generates_new_seed_when_failed_keyword_present_but_no_stored_seed
+      Reviewer.instance_variable_set(:@arguments, Arguments.new(%w[failed]))
+
+      command = Reviewer::Command.new(:dynamic_seed_tool, :review)
+      assert_kind_of Integer, command.seed
+    ensure
+      Reviewer.reset!
+      ensure_test_configuration!
+    end
+
     def test_can_be_cast_to_string
       command_string = "WITH_SPACES='with spaces' WORD=second INTEGER=1 BOOLEAN=true ls -c --third 'third flag' --fourth 'fourth flag'"
 

--- a/test/reviewer/output_test.rb
+++ b/test/reviewer/output_test.rb
@@ -88,5 +88,15 @@ module Reviewer
       out, _err = capture_subprocess_io { @output.guidance('Test', nil) }
       assert out.strip.empty?
     end
+
+    def test_no_failures_to_retry
+      out, _err = capture_subprocess_io { @output.no_failures_to_retry }
+      assert_match(/No failures to retry/i, out)
+    end
+
+    def test_no_previous_run
+      out, _err = capture_subprocess_io { @output.no_previous_run }
+      assert_match(/No previous run found/i, out)
+    end
   end
 end

--- a/test/reviewer_test.rb
+++ b/test/reviewer_test.rb
@@ -8,9 +8,17 @@ module Reviewer
     def to_a = []
   end
 
+  # Minimal keywords stub that reports no failed keyword
+  StubKeywords = Struct.new(nil) do
+    def failed? = false
+    def for_tool_names = []
+  end
+
   # Stub for testing different argument configurations
   StubArgs = Struct.new(:format, :json?, :raw?, :streaming?, keyword_init: true) do
     def files = EmptyFiles.new
+    def keywords = StubKeywords.new
+    def tags = []
   end
 
   class ReviewerTest < Minitest::Test


### PR DESCRIPTION
## Summary

- `rvw failed` re-runs only tools that failed in the previous run
- Composes with existing keywords via union: `rvw failed rubocop` runs failed tools + rubocop
- Re-uses the stored random seed from the last run for reproducibility
- Records per-tool pass/fail status in history after each batch run
- Handles edge cases: "No previous run found" and "No failures to retry" when `failed` is the sole keyword

## Implementation

1. **Batch** records `:last_status` (`:passed` / `:failed`) per tool after each run, clearing stale statuses before the batch starts
2. **Keywords** adds `failed` to `RESERVED` with a `failed?` predicate
3. **Tools** adds `failed` as a peer to `specified` and `tagged` in `Tools#current`, querying history for tools with `:failed` status
4. **Reviewer** exits cleanly with a message when `failed` is the sole keyword and there's nothing to re-run
5. **Command** prefers the stored seed from history when `failed` keyword is present
6. **Timer** uses anonymous block forwarding (Rubocop fix)

## Test plan

- [x] Batch records passed/failed/nil status correctly (3 tests)
- [x] `failed` is a reserved keyword with `failed?` predicate (2 tests)
- [x] `failed_from_history` returns correct tools, `current` unions them (4 tests)
- [x] Edge case messages for no failures and no previous run (2 tests)
- [x] Seed re-use when `failed` keyword present (3 tests)
- [x] Full suite passes: 302 tests, 601 assertions