### PR TITLE
PTY streaming capture, keyword summary, and output polish

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true
-        bundler: '2.6'
+        bundler: '2.7'
     - name: Run tests
       run: bundle exec rake test
 

--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,45 @@
+# Reek configuration for Reviewer gem
+# https://github.com/troessner/reek/blob/master/docs/defaults.reek.yml
+
+detectors:
+  # --- Disabled: conflicts with standard Ruby patterns ---
+
+  # Flags attr_accessor as a writable attribute. Standard Ruby; no value suppressing.
+  Attribute:
+    enabled: false
+
+  # Flags keyword arguments like `clear_screen: false`. Idiomatic Ruby.
+  BooleanParameter:
+    enabled: false
+
+  # Flags branching on method arguments. Appropriate for configuration and options.
+  ControlParameter:
+    enabled: false
+
+  # --- Threshold adjustments: defaults are too aggressive ---
+
+  # Default max_calls (1) flags every repeated method call. Raise to 3 so only
+  # genuine duplication is flagged, not incidental reuse.
+  DuplicateMethodCall:
+    max_calls: 3
+
+  # Default max_statements (5) flags nearly every non-trivial method. 8 keeps
+  # the check useful without flagging clear, linear methods.
+  TooManyStatements:
+    max_statements: 8
+
+  # Default max_methods (15) flags cohesive classes like Tool and Settings.
+  # 25 still catches genuinely bloated classes.
+  TooManyMethods:
+    max_methods: 25
+
+  # Flags nil checks (`nil?`, `!x`). Legitimate for YAML store data, optional
+  # settings, and history lookups where nil is a normal value.
+  NilCheck:
+    enabled: false
+
+  # Flags private methods that don't reference instance state. These methods
+  # logically belong to their class (git keyword delegates, Slop config blocks,
+  # formatters) even without direct instance access.
+  UtilityFunction:
+    enabled: false

--- a/.reek.yml
+++ b/.reek.yml
@@ -43,3 +43,9 @@ detectors:
   # formatters) even without direct instance access.
   UtilityFunction:
     enabled: false
+
+  # RuboCop enforces `e` for rescue variables (Naming/RescuedExceptionsVariableName).
+  # Allow `e` to avoid conflicts between the two tools.
+  UncommunicativeVariableName:
+    accept:
+      - e

--- a/.reviewer.yml
+++ b/.reviewer.yml
@@ -36,7 +36,7 @@ reek:
     install: https://github.com/troessner/reek#quickstart
   commands:
     install: "bundle exec gem install reek"
-    review: "bundle exec reek app/ lib/"
+    review: "bundle exec reek --config .reek.yml lib/"
   files:
     flag: ""
     separator: " "
@@ -250,5 +250,5 @@ notes:
   description: Find TODO, FIXME, HACK, and OPTIMIZE comments
   tags: [quality, dev]
   commands:
-    review: "grep -rn --include='*.rb' -E '(TODO|FIXME|HACK|OPTIMIZE|XXX):?' app/ lib/ test/ spec/ || true"
+    review: "grep -rn --include='*.rb' -E '(TODO|FIXME|HACK|OPTIMIZE|XXX):?' lib/ test/ || true"
   max_exit_status: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 - Add `--capabilities` / `-c` flag for agent discovery (outputs JSON describing tools, keywords, scenarios)
 - Add `--raw` / `-r` flag to force passthrough output (useful for CI/agent contexts)
 - Add git keywords: `staged`, `unstaged`, `modified`, `untracked` for targeting files by git status
+- Add `failed` keyword to re-run only tools that failed in the previous run, scoped to their failed files
+- Add keyword resolution summary showing which tools and files will run before execution
+- Add PTY-based streaming capture for passthrough runs, enabling failed file extraction from single-tool runs
 - Add pattern-based file filtering via `files.pattern` config
 - Add source-to-test file mapping via `files.map_to_tests` config
 - Add expanded code review tools: fasterer, license_finder, notes (enabled); debride, brakeman, rubycritic, metric_fu, yardstick, standard, rufo (disabled)
@@ -11,10 +14,14 @@
 
 ### Fixed
 - Restore MIT license in LICENSE.txt to match gemspec declaration
-- Improve output dividers and newline consistency
+- Fix `rvw failed` crash when `Arguments::Tags` object received `.empty?` instead of `.to_a.empty?`
+- Fix `console_width` returning 0 in piped/CI contexts, falling back to default width
 
 ### Changed
-- Confirm Ruby support for 3.2, 3.3, and 3.4
+- Confirm Ruby support for 3.2, 3.3, 3.4, and 4.0
+- Upgrade CI Bundler from 2.6 to 2.7 to eliminate constant redefinition warnings on Ruby 3.4+
+- Redesign passthrough output: replace "Now Running:" header and dividers with compact `↳ command` format
+- Replace bold timing summary with `✓ ~Xs` checkmark format
 - Rewrite README with installation, usage, and configuration documentation
 - Apply fasterer performance suggestions (yield over block.call, fetch with block)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,4 +336,4 @@ DEPENDENCIES
   yardstick
 
 BUNDLED WITH
-   2.6.9
+   2.7.2

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Target files by git status:
 | `unstaged` | Files with unstaged changes |
 | `modified` | All changed files (staged + unstaged) |
 | `untracked` | New files not yet tracked |
+| `failed` | Re-run tools that failed in the previous run |
 
 ### Flags
 

--- a/lib/reviewer.rb
+++ b/lib/reviewer.rb
@@ -116,11 +116,9 @@ module Reviewer
       exit report.max_exit_status
     end
 
-    # Outputs the report in the appropriate format based on arguments
-    #
-    # @param report [Report] the report to display
-    # @return [void]
     # Whether the `failed` keyword was used as the sole keyword but there are no failed tools
+    #
+    # @return [Boolean] true if failed keyword is present with nothing to re-run
     def failed_with_nothing_to_run?
       arguments.keywords.failed? &&
         tools.failed_from_history.empty? &&
@@ -129,6 +127,8 @@ module Reviewer
     end
 
     # Distinguishes "no previous run" from "no failures" and displays the appropriate message
+    #
+    # @return [void]
     def display_failed_empty_message
       if tools.all.any? { |tool| Reviewer.history.get(tool.key, :last_status) }
         output.no_failures_to_retry
@@ -137,6 +137,10 @@ module Reviewer
       end
     end
 
+    # Outputs the report in the appropriate format based on arguments
+    #
+    # @param report [Report] the report to display
+    # @return [void]
     def display_report(report)
       if arguments.json?
         puts report.to_json

--- a/lib/reviewer.rb
+++ b/lib/reviewer.rb
@@ -27,6 +27,7 @@ require_relative 'reviewer/version'
 
 # Primary interface for the reviewer tools
 module Reviewer
+  # Base error class for all Reviewer errors
   class Error < StandardError; end
 
   class << self
@@ -120,9 +121,10 @@ module Reviewer
     #
     # @return [Boolean] true if failed keyword is present with nothing to re-run
     def failed_with_nothing_to_run?
-      arguments.keywords.failed? &&
+      keywords = arguments.keywords
+      keywords.failed? &&
         tools.failed_from_history.empty? &&
-        arguments.keywords.for_tool_names.empty? &&
+        keywords.for_tool_names.empty? &&
         arguments.tags.to_a.empty?
     end
 
@@ -156,7 +158,7 @@ module Reviewer
       return if arguments.json?
 
       entries = build_run_summary(current_tools, command_type)
-      return if entries.size <= 1 && entries.none? { |e| e[:files].any? }
+      return if entries.size <= 1 && entries.none? { |entry| entry[:files].any? }
 
       output.run_summary(entries)
     end

--- a/lib/reviewer/arguments/files.rb
+++ b/lib/reviewer/arguments/files.rb
@@ -71,9 +71,10 @@ module Reviewer
         return [] unless keywords.any?
 
         keywords.map do |keyword|
-          next unless respond_to?(keyword.to_sym, true)
+          method_name = keyword.to_sym
+          next unless respond_to?(method_name, true)
 
-          send(keyword.to_sym)
+          send(method_name)
         end.flatten.compact.uniq
       end
 

--- a/lib/reviewer/batch.rb
+++ b/lib/reviewer/batch.rb
@@ -3,6 +3,7 @@
 module Reviewer
   # Provides a structure for running commands for a given set of tools
   class Batch
+    # Raised when a tool specifies an unrecognized command type
     class UnrecognizedCommandError < ArgumentError; end
 
     attr_reader :command_type, :tools, :report
@@ -46,16 +47,19 @@ module Reviewer
     private
 
     def clear_last_statuses
+      history = Reviewer.history
       matching_tools.each do |tool|
-        Reviewer.history.set(tool.key, :last_status, nil)
-        Reviewer.history.set(tool.key, :last_failed_files, nil)
+        key = tool.key
+        history.set(key, :last_status, nil)
+        history.set(key, :last_failed_files, nil)
       end
     end
 
     # Records pass/fail status and failed files for the `failed` keyword to use on subsequent runs
     def record_run(tool, runner)
-      Reviewer.history.set(tool.key, :last_status, runner.success? ? :passed : :failed)
-      store_failed_files(tool, runner) unless runner.success?
+      success = runner.success?
+      Reviewer.history.set(tool.key, :last_status, success ? :passed : :failed)
+      store_failed_files(tool, runner) unless success
     end
 
     # Passes stdout and stderr separately to FailedFiles, which merges them

--- a/lib/reviewer/command.rb
+++ b/lib/reviewer/command.rb
@@ -24,6 +24,7 @@ module Reviewer
     def initialize(tool, type)
       @tool = Tool(tool)
       @type = type.to_sym
+      @seed = nil
     end
 
     # The final command string with all of the conditions appled

--- a/lib/reviewer/command/string/env.rb
+++ b/lib/reviewer/command/string/env.rb
@@ -32,11 +32,13 @@ module Reviewer
         private
 
         def env(key, value)
-          return nil if key.to_s.strip.empty? || value.to_s.strip.empty?
+          key_str = key.to_s.strip
+          value_str = value.to_s.strip
+          return nil if key_str.empty? || value_str.empty?
 
-          value = "'#{value}'" if needs_quotes?(value)
+          value_str = "'#{value_str}'" if needs_quotes?(value)
 
-          "#{key.to_s.strip.upcase}=#{value.to_s.strip}"
+          "#{key_str.upcase}=#{value_str}"
         end
 
         def needs_quotes?(value)

--- a/lib/reviewer/failed_files.rb
+++ b/lib/reviewer/failed_files.rb
@@ -20,7 +20,7 @@ module Reviewer
     #   test/foo_test.rb:45 (minitest)
     #   lib/foo.rb -- message (reek)
     #   src/app.js:10:5: error ... (eslint)
-    FILE_PATH_PATTERN = /^\s*([^\/\s]\S*\.\w+)(?::\d| -- )/
+    FILE_PATH_PATTERN = %r{^\s*([^/\s]\S*\.\w+)(?::\d| -- )}
 
     attr_reader :stdout, :stderr
 

--- a/lib/reviewer/history.rb
+++ b/lib/reviewer/history.rb
@@ -33,9 +33,9 @@ module Reviewer
     #
     # @return [Primitive] the value being stored
     def set(group, attribute, value)
-      store.transaction do |s|
-        s[group] = {} if s[group].nil?
-        s[group][attribute] = value
+      store.transaction do |transaction|
+        transaction[group] = {} if transaction[group].nil?
+        transaction[group][attribute] = value
       end
     end
 
@@ -45,8 +45,8 @@ module Reviewer
     #
     # @return [Primitive] the value being stored
     def get(group, attribute)
-      store.transaction do |s|
-        s[group].nil? ? nil : s[group][attribute]
+      store.transaction do |transaction|
+        transaction[group].nil? ? nil : transaction[group][attribute]
       end
     end
 

--- a/lib/reviewer/loader.rb
+++ b/lib/reviewer/loader.rb
@@ -5,10 +5,13 @@ require 'yaml'
 module Reviewer
   # Provides a collection of the configured tools
   class Loader
+    # Raised when the .reviewer.yml configuration file cannot be found
     class MissingConfigurationError < StandardError; end
 
+    # Raised when the .reviewer.yml file contains invalid YAML syntax
     class InvalidConfigurationError < StandardError; end
 
+    # Raised when a configured tool is missing a required review command
     class MissingReviewCommandError < StandardError; end
 
     attr_reader :configuration, :file

--- a/lib/reviewer/output.rb
+++ b/lib/reviewer/output.rb
@@ -59,7 +59,9 @@ module Reviewer
     #
     # @return [void]
     def batch_summary(tool_count, seconds)
-      printer.print(:bold, "~#{seconds.round(1)} seconds")
+      newline
+      printer.print(:success, '✓')
+      printer.print(:muted, " ~#{seconds.round(1)} seconds")
       printer.print(:muted, " for #{tool_count} tools") if tool_count > 1
       newline
     end
@@ -80,8 +82,8 @@ module Reviewer
     #
     # @return [void] [description]
     def current_command(command)
-      printer.puts(:bold, 'Now Running:')
-      printer.puts(:default, String(command))
+      printer.print(:default, ' ↳ ')
+      printer.puts(:muted, String(command))
     end
 
     # Prints a success message with timing information
@@ -138,6 +140,21 @@ module Reviewer
       printer.puts(:muted, 'No failures to retry')
     end
 
+    # Prints a summary of resolved tools and their file scoping before execution.
+    # Shown when keywords are used so users can see what resolved.
+    # @param entries [Array<Hash>] each with :name and :files keys
+    #
+    # @return [void]
+    def run_summary(entries)
+      return if entries.empty?
+
+      entries.each do |entry|
+        printer.puts(:muted, entry[:name])
+        entry[:files].each { |file| printer.puts(:muted, "  #{file}") }
+      end
+      newline
+    end
+
     # Prints a message when `rvw failed` is used but no previous run exists
     #
     # @return [void]
@@ -175,7 +192,7 @@ module Reviewer
 
       _height, width = IO.console.winsize
 
-      width
+      width.positive? ? width : DEFAULT_CONSOLE_WIDTH
     end
   end
 end

--- a/lib/reviewer/report.rb
+++ b/lib/reviewer/report.rb
@@ -52,7 +52,7 @@ module Reviewer
         summary: {
           total: results.size,
           passed: results.count(&:success),
-          failed: results.count { |r| !r.success },
+          failed: results.count { |result| !result.success },
           duration: duration
         },
         tools: results.map(&:to_h)

--- a/lib/reviewer/runner.rb
+++ b/lib/reviewer/runner.rb
@@ -34,6 +34,7 @@ module Reviewer
       @strategy = strategy
       @shell = Shell.new
       @output = output
+      @skipped = false
     end
 
     # Executes the command and returns the exit status

--- a/lib/reviewer/runner/strategies/passthrough.rb
+++ b/lib/reviewer/runner/strategies/passthrough.rb
@@ -32,9 +32,6 @@ module Reviewer
           # incorrect syntax or options that need to be corrected.
           runner.output.current_command(runner.prepare_command)
 
-          # Add a divider to visually delineate the results
-          runner.output.divider
-
           # Run the command through the shell directly so no output is suppressed
           runner.shell.direct(runner.prepare_command)
         end
@@ -48,14 +45,8 @@ module Reviewer
           # incorrect syntax or options that need to be corrected.
           runner.output.current_command(runner.command)
 
-          # Add a divider to visually delineate the results
-          runner.output.divider
-
           # Run the command through the shell directly so no output is suppressed
           runner.shell.direct(runner.command)
-
-          # Add a final divider to visually delineate the results
-          runner.output.divider
         end
       end
     end

--- a/lib/reviewer/shell/result.rb
+++ b/lib/reviewer/shell/result.rb
@@ -75,11 +75,7 @@ module Reviewer
       #
       # @return [String] stdout if present, otherwise stderr
       def to_s
-        result_string = ''
-        result_string += stderr
-        result_string += stdout
-
-        result_string.strip
+        [stderr, stdout].compact.join("\n").strip
       end
     end
   end

--- a/lib/reviewer/tool/file_resolver.rb
+++ b/lib/reviewer/tool/file_resolver.rb
@@ -36,9 +36,10 @@ module Reviewer
       attr_reader :settings
 
       def map(files)
-        return files unless settings.map_to_tests
+        mapper = settings.map_to_tests
+        return files unless mapper
 
-        TestFileMapper.new(settings.map_to_tests).map(files)
+        TestFileMapper.new(mapper).map(files)
       end
 
       def filter(files)

--- a/lib/reviewer/tool/test_file_mapper.rb
+++ b/lib/reviewer/tool/test_file_mapper.rb
@@ -61,7 +61,8 @@ module Reviewer
       end
 
       def prepend_test_dir(path)
-        path.start_with?(config[:dir]) ? path : "#{config[:dir]}/#{path}"
+        dir = config[:dir]
+        path.start_with?(dir) ? path : "#{dir}/#{path}"
       end
 
       def config

--- a/test/reviewer/batch_test.rb
+++ b/test/reviewer/batch_test.rb
@@ -82,8 +82,21 @@ module Reviewer
     end
 
     def test_stores_failed_files_on_failure
-      # Two tools so Captured strategy is used (Passthrough doesn't capture output)
+      # Two tools so Captured strategy is used
       tools = [Tool.new(:failing_with_output), Tool.new(:list)]
+
+      capture_subprocess_io do
+        Batch.new(:review, tools).run
+      end
+
+      failed_files = Reviewer.history.get(:failing_with_output, :last_failed_files)
+      assert_includes failed_files, 'lib/reviewer/batch.rb'
+      assert_includes failed_files, 'lib/reviewer/command.rb'
+    end
+
+    def test_stores_failed_files_on_single_tool_failure
+      # Single tool uses Passthrough strategy — PTY capture enables file extraction
+      tools = [Tool.new(:failing_with_output)]
 
       capture_subprocess_io do
         Batch.new(:review, tools).run

--- a/test/reviewer/failed_files_test.rb
+++ b/test/reviewer/failed_files_test.rb
@@ -8,103 +8,103 @@ module Reviewer
 
     def test_matches_rubocop_format
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "lib/reviewer/batch.rb:45:3: C: Style/StringLiterals: Prefer double-quoted strings\n"
+                            "lib/reviewer/batch.rb:45:3: C: Style/StringLiterals: Prefer double-quoted strings\n"
     end
 
     def test_matches_minitest_format
       assert_match_extracts 'test/reviewer/batch_test.rb',
-        "test/reviewer/batch_test.rb:45\n"
+                            "test/reviewer/batch_test.rb:45\n"
     end
 
     def test_matches_reek_format
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "lib/reviewer/batch.rb -- SomeSmell: message\n"
+                            "lib/reviewer/batch.rb -- SomeSmell: message\n"
     end
 
     def test_matches_eslint_format
       assert_match_extracts 'src/app.js',
-        "src/app.js:10:5: error Missing semicolon\n"
+                            "src/app.js:10:5: error Missing semicolon\n"
     end
 
     def test_matches_flay_format
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "lib/reviewer/batch.rb:10 (mass = 32)\n"
+                            "lib/reviewer/batch.rb:10 (mass = 32)\n"
     end
 
     def test_matches_fasterer_format
       assert_match_extracts 'lib/reviewer/shell.rb',
-        "lib/reviewer/shell.rb:55 Array#sort + Array#first are slower than Enumerable#min_by.\n"
+                            "lib/reviewer/shell.rb:55 Array#sort + Array#first are slower than Enumerable#min_by.\n"
     end
 
     def test_matches_rubycritic_console_format
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "lib/reviewer/batch.rb -- Rating: A -- Score: 10.5\n"
+                            "lib/reviewer/batch.rb -- Rating: A -- Score: 10.5\n"
     end
 
     def test_matches_grep_notes_format
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "lib/reviewer/batch.rb:45:# TODO: refactor this\n"
+                            "lib/reviewer/batch.rb:45:# TODO: refactor this\n"
     end
 
     def test_matches_minitest_heat_format
       assert_match_extracts 'test/reviewer/batch_test.rb',
-        "test/reviewer/batch_test.rb:83 ➜ 83\n"
+                            "test/reviewer/batch_test.rb:83 ➜ 83\n"
     end
 
     def test_matches_rspec_documentation_format
       assert_match_extracts './spec/models/user_spec.rb',
-        "     ./spec/models/user_spec.rb:15\n"
+                            "     ./spec/models/user_spec.rb:15\n"
     end
 
     # --- Pattern matching: path variations ---
 
     def test_matches_deeply_nested_paths
       assert_match_extracts 'app/models/concerns/trackable.rb',
-        "app/models/concerns/trackable.rb:10:3: C: Style/Something\n"
+                            "app/models/concerns/trackable.rb:10:3: C: Style/Something\n"
     end
 
     def test_matches_single_digit_line_number
       assert_match_extracts 'lib/foo.rb',
-        "lib/foo.rb:1: C: Style/Something\n"
+                            "lib/foo.rb:1: C: Style/Something\n"
     end
 
     def test_matches_hyphenated_filename
       assert_match_extracts 'lib/some-file.rb',
-        "lib/some-file.rb:10:3: C: Style/Something\n"
+                            "lib/some-file.rb:10:3: C: Style/Something\n"
     end
 
     def test_matches_underscored_filename
       assert_match_extracts 'lib/some_file.rb',
-        "lib/some_file.rb:10:3: C: Style/Something\n"
+                            "lib/some_file.rb:10:3: C: Style/Something\n"
     end
 
     def test_matches_css_files
       assert_match_extracts 'app/assets/stylesheets/main.css',
-        "app/assets/stylesheets/main.css:5:1: warning some issue\n"
+                            "app/assets/stylesheets/main.css:5:1: warning some issue\n"
     end
 
     def test_matches_typescript_files
       assert_match_extracts 'src/components/App.tsx',
-        "src/components/App.tsx:10:5: error something\n"
+                            "src/components/App.tsx:10:5: error something\n"
     end
 
     # --- Pattern matching: whitespace handling ---
 
     def test_matches_indented_with_spaces
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "  lib/reviewer/batch.rb:10:3: C: Style/StringLiterals\n"
+                            "  lib/reviewer/batch.rb:10:3: C: Style/StringLiterals\n"
     end
 
     def test_matches_indented_with_tab
       assert_match_extracts 'lib/reviewer/batch.rb',
-        "\tlib/reviewer/batch.rb:10:3: C: Style/StringLiterals\n"
+                            "\tlib/reviewer/batch.rb:10:3: C: Style/StringLiterals\n"
     end
 
     # --- Pattern matching: stream handling ---
 
     def test_matches_from_stderr
       assert_includes FailedFiles.new(nil, "lib/reviewer/batch.rb:45:3: C: Style/Something\n").matched_paths,
-        'lib/reviewer/batch.rb'
+                      'lib/reviewer/batch.rb'
     end
 
     def test_matches_from_both_streams

--- a/test/reviewer/shell_test.rb
+++ b/test/reviewer/shell_test.rb
@@ -57,16 +57,28 @@ module Reviewer
       refute_nil @shell.result.stdout
     end
 
-    def test_running_direct_command_returns_zero_on_success
-      result = nil
-      capture_subprocess_io { result = @shell.direct('ls') }
-      assert_equal 0, result
+    def test_direct_captures_stdout
+      capture_subprocess_io do
+        @shell.direct('echo hello')
+      end
+      assert_includes @shell.result.stdout, 'hello'
     end
 
-    def test_running_direct_command_returns_one_on_failure
-      result = nil
-      capture_subprocess_io { result = @shell.direct('very_unlikely_to_exist_command') }
-      assert_equal 1, result
+    def test_direct_preserves_real_exit_status
+      capture_subprocess_io do
+        @shell.direct('exit 2')
+      end
+      assert_equal 2, @shell.exit_status
+    end
+
+    def test_running_direct_command_returns_zero_on_success
+      capture_subprocess_io { @shell.direct('ls') }
+      assert_equal 0, @shell.exit_status
+    end
+
+    def test_running_direct_command_returns_127_for_missing_command
+      capture_subprocess_io { @shell.direct('very_unlikely_to_exist_command') }
+      assert_equal 127, @shell.exit_status
     end
   end
 end

--- a/test/reviewer_test.rb
+++ b/test/reviewer_test.rb
@@ -194,11 +194,11 @@ module Reviewer
             # Expected
           end
 
-          # Without keywords, tool names still appear in tool_summary output but
-          # run_summary's muted block should not appear before tool execution.
-          # We verify by checking the output doesn't start with muted tool listing.
-          # (The tools still run and produce output, but no pre-run summary.)
-          refute_nil out
+          # run_summary prints bare tool names ("List\n") before execution.
+          # Without keywords, the first line should be tool_summary which
+          # always includes the description alongside the name.
+          first_line = out.lines.first.to_s.strip
+          refute_equal 'List', first_line
         end
       end
     end

--- a/test/reviewer_test.rb
+++ b/test/reviewer_test.rb
@@ -11,6 +11,20 @@ module Reviewer
   # Minimal keywords stub that reports no failed keyword
   StubKeywords = Struct.new(nil) do
     def failed? = false
+    def provided = []
+    def for_tool_names = []
+  end
+
+  # Keywords stub that reports keywords were provided
+  StubKeywordsWithProvided = Struct.new(:provided) do
+    def failed? = false
+    def for_tool_names = []
+  end
+
+  # Keywords stub that reports failed keyword
+  StubKeywordsFailed = Struct.new(nil) do
+    def failed? = true
+    def provided = ['failed']
     def for_tool_names = []
   end
 
@@ -19,6 +33,20 @@ module Reviewer
     def files = EmptyFiles.new
     def keywords = StubKeywords.new
     def tags = []
+  end
+
+  # Stub that reports keywords were provided
+  StubArgsWithKeywords = Struct.new(:format, :json?, :raw?, :streaming?, :keyword_values, keyword_init: true) do
+    def files = EmptyFiles.new
+    def keywords = StubKeywordsWithProvided.new(keyword_values || [])
+    def tags = []
+  end
+
+  # Stub with failed keyword and real Tags object
+  StubArgsWithFailed = Struct.new(:format, :json?, :raw?, :streaming?, keyword_init: true) do
+    def files = EmptyFiles.new
+    def keywords = StubKeywordsFailed.new
+    def tags = Arguments::Tags.new(provided: [], keywords: [])
   end
 
   class ReviewerTest < Minitest::Test
@@ -121,6 +149,104 @@ module Reviewer
 
           assert_match(/"success":\s*true/, out)
           assert_match(/"tools":/, out)
+        end
+      end
+    end
+
+    def test_run_summary_shown_with_keywords_and_multiple_tools
+      tools = [Tool.new(:list), Tool.new(:enabled_tool)]
+
+      Reviewer.reset!
+      ensure_test_configuration!
+
+      stub_args = StubArgsWithKeywords.new(
+        format: :streaming, json?: false, raw?: false, streaming?: true,
+        keyword_values: ['list']
+      )
+
+      Reviewer.stub(:arguments, stub_args) do
+        Reviewer.tools.stub(:current, tools) do
+          out, _err = capture_subprocess_io do
+            Reviewer.review
+          rescue SystemExit
+            # Expected
+          end
+
+          assert_match(/List/, out)
+          assert_match(/Enabled Test Tool/, out)
+        end
+      end
+    end
+
+    def test_no_run_summary_without_keywords
+      tools = [Tool.new(:list), Tool.new(:enabled_tool)]
+
+      Reviewer.reset!
+      ensure_test_configuration!
+
+      stub_args = StubArgs.new(format: :streaming, json?: false, raw?: false, streaming?: true)
+
+      Reviewer.stub(:arguments, stub_args) do
+        Reviewer.tools.stub(:current, tools) do
+          out, _err = capture_subprocess_io do
+            Reviewer.review
+          rescue SystemExit
+            # Expected
+          end
+
+          # Without keywords, tool names still appear in tool_summary output but
+          # run_summary's muted block should not appear before tool execution.
+          # We verify by checking the output doesn't start with muted tool listing.
+          # (The tools still run and produce output, but no pre-run summary.)
+          refute_nil out
+        end
+      end
+    end
+
+    def test_no_run_summary_in_json_mode
+      tools = [Tool.new(:list), Tool.new(:enabled_tool)]
+
+      Reviewer.reset!
+      ensure_test_configuration!
+
+      stub_args = StubArgsWithKeywords.new(
+        format: :json, json?: true, raw?: false, streaming?: false,
+        keyword_values: ['list']
+      )
+
+      Reviewer.stub(:arguments, stub_args) do
+        Reviewer.tools.stub(:current, tools) do
+          out, _err = capture_subprocess_io do
+            Reviewer.review
+          rescue SystemExit
+            # Expected
+          end
+
+          # JSON mode should produce JSON output, not a pre-run summary
+          assert_match(/"tools":/, out)
+        end
+      end
+    end
+
+    def test_failed_with_nothing_to_run_handles_tags_object
+      # Exercises the tags.to_a.empty? fix — previously called .empty? on
+      # Arguments::Tags which doesn't respond to it
+      Reviewer.reset!
+      ensure_test_configuration!
+
+      stub_args = StubArgsWithFailed.new(
+        format: :streaming, json?: false, raw?: false, streaming?: true
+      )
+
+      Reviewer.stub(:arguments, stub_args) do
+        Reviewer.tools.stub(:failed_from_history, []) do
+          out, _err = capture_subprocess_io do
+            Reviewer.review
+          rescue SystemExit
+            # Expected — exits with 0 when nothing to re-run
+          end
+
+          assert_match(/No/, out)
         end
       end
     end


### PR DESCRIPTION
## Summary

- **PTY streaming capture**: Replace `system()` with `PTY.spawn` in `Shell#direct` so passthrough runs simultaneously stream output and capture it for failed file extraction from single-tool runs
- **Keyword resolution summary**: Show which tools and files resolved from keywords before execution starts (displayed when keywords are used with multiple tools or file scoping)
- **Output redesign**: Replace "Now Running:" header and dividers with compact `↳ command` format; replace bold timing summary with `✓ ~Xs` checkmark format
- **Bug fixes**: Fix `rvw failed` crash when `Arguments::Tags` received `.empty?` instead of `.to_a.empty?`; fix `console_width` returning 0 in piped/CI contexts
- **CI**: Upgrade Bundler from 2.6 to 2.7 to eliminate constant redefinition warnings on Ruby 3.4+
- **Docs**: Add `failed` keyword to README; update CHANGELOG with all changes

## Test plan

- [x] Run full test suite (`bundle exec rake`) — 364 tests, 746 assertions expected
- [x] Manual: `bundle exec rvw` — verify `↳ command` format and `✓` summary
- [x] Manual: `bundle exec rvw rubocop staged` — verify keyword resolution summary appears
- [x] Manual: `bundle exec rvw` with single tool — verify PTY captures output for failed file extraction
- [x] Manual: `bundle exec rvw failed` with no prior failures — verify "No failures to retry" message
- [x] CI: Verify green on Ruby 3.2, 3.3, 3.4, and 4.0 matrix