### PR TITLE
Replace manual progress display with ruby-progressbar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       benchmark
       pstore
       rainbow
+      ruby-progressbar
       slop
 
 GEM

--- a/reviewer.gemspec
+++ b/reviewer.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'benchmark'
   spec.add_dependency 'pstore'
   spec.add_dependency 'rainbow'
+  spec.add_dependency 'ruby-progressbar'
   spec.add_dependency 'slop'
 
   spec.add_development_dependency 'minitest', '~> 5.0'


### PR DESCRIPTION
## Summary

- Add `ruby-progressbar` runtime dependency to replace the manual `> ~75%` carriage-return progress display in the captured strategy
- Determinate bar (with percentage and optional ETA for tools ≥3s) when historical timing data exists; indeterminate cycling animation for first runs
- ANSI 256-color format strings keep the bar visually subdued (gray tones instead of bright white)
- Use `bar.stop` for indeterminate bars and `bar.finish` for determinate bars to avoid broken output on completion
- Add `thread.join` after the progress loop to surface thread exceptions instead of silently swallowing them

## Test plan

- [x] `bundle exec rake` — all 364 tests pass
- [x] `bundle exec ./exe/rvw` — visual check of progress bar with existing history
- [x] Delete `.reviewer_history.yml` and re-run — visual check of indeterminate animation
- [x] Run single tool (`bundle exec ./exe/rvw rubocop`) — uses Passthrough, unaffected